### PR TITLE
Re-add simple polynomial macro

### DIFF
--- a/spindalis/src/polynomials/core/simple.rs
+++ b/spindalis/src/polynomials/core/simple.rs
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_parse_simple_polynomial_multiple_terms_same_power() {
-        let coeffs = parse_simple_polynomial("2x^2+3x^2")
+        let coeffs = parse_simple_polynomial("2x^2+3x^2").unwrap();
         let coeffs_macro = parse_simple_polynomial!(2 x^2 + 3 x^2);
 
         let result = vec![


### PR DESCRIPTION
The macro created by @rbran was lost in the shuffle when files were renamed and moved around. This is me adding his implementation back to the project exactly as he had it.