### PR TITLE
Add div, min, and max to Arr2D

### DIFF
--- a/spindalis/Cargo.lock
+++ b/spindalis/Cargo.lock
@@ -13,16 +13,16 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "spindalis"
-version = "0.0.2"
+version = "0.4.1"
 dependencies = [
  "spindalis_core",
  "spindalis_macros",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "spindalis_core"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "spindalis_macros"

--- a/spindalis/Cargo.toml
+++ b/spindalis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spindalis"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 [lib]

--- a/spindalis/src/utils/arr2D.rs
+++ b/spindalis/src/utils/arr2D.rs
@@ -2,7 +2,7 @@ use crate::utils::Arr2DError;
 use std::{
     any::type_name,
     fmt::{self, Display},
-    ops::{Index, IndexMut, Mul},
+    ops::{Div, Index, IndexMut, Mul},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
@@ -25,6 +25,38 @@ impl<T> Arr2D<T> {
 
     pub fn is_empty(&self) -> bool {
         self.height == 0 || self.width == 0
+    }
+
+    pub fn max(&self) -> Option<T>
+    where
+        T: std::cmp::PartialOrd + Clone,
+    {
+        if self.is_empty() {
+            return None;
+        }
+        Some(
+            self.inner
+                .iter()
+                .reduce(|a, b| if a > b { a } else { b })
+                .unwrap()
+                .clone(),
+        )
+    }
+
+    pub fn min(&self) -> Option<T>
+    where
+        T: std::cmp::PartialOrd + Clone,
+    {
+        if self.is_empty() {
+            return None;
+        }
+        Some(
+            self.inner
+                .iter()
+                .reduce(|a, b| if a < b { a } else { b })
+                .unwrap()
+                .clone(),
+        )
     }
 
     /// Change the height and width
@@ -175,6 +207,23 @@ where
         for i in 0..self.height {
             for j in 0..self.width {
                 result[i][j] = self[i][j] * rhs;
+            }
+        }
+        result
+    }
+}
+
+impl<T> Div<T> for Arr2D<T>
+where
+    T: Div<Output = T> + Clone + std::default::Default + std::marker::Copy,
+{
+    type Output = Arr2D<T>;
+
+    fn div(self, rhs: T) -> Self {
+        let mut result = Arr2D::full(T::default(), self.height, self.width);
+        for i in 0..self.height {
+            for j in 0..self.width {
+                result[i][j] = self[i][j] / rhs;
             }
         }
         result
@@ -930,6 +979,15 @@ mod tests {
         assert_eq!(res, expected);
     }
 
+    #[test]
+    fn test_Div_trait_mat_div_scalar() {
+        let mat = Arr2D::from_flat(vec![1.778, 0.0, 1.778], 0.0, 3, 1).unwrap();
+        let result = mat / 1.778;
+        let expected = Arr2D::from(&[[1.0], [0.0], [1.0]]);
+
+        assert_eq!(result, expected);
+    }
+
     // --- misc ---
 
     #[test]
@@ -940,5 +998,41 @@ mod tests {
 [[    1.2, 34.5678 ]
  [ 789.02,   0.123 ]]"#;
         assert_eq!(&out, &expected[1..]);
+    }
+
+    #[test]
+    fn test_int_max() {
+        let data = Arr2D::from(&[[12], [10], [11], [20], [9]]);
+        let result = data.max().unwrap();
+        let expected = 20;
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_float_max() {
+        let data = Arr2D::from(&[[23.3], [12.4], [23.4], [10.4]]);
+        let result = data.max().unwrap();
+        let expected = 23.4;
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_int_min() {
+        let data = Arr2D::from(&[[12], [10], [11], [20], [9]]);
+        let result = data.min().unwrap();
+        let expected = 9;
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_float_min() {
+        let data = Arr2D::from(&[[23.3], [12.4], [23.4], [10.4]]);
+        let result = data.min().unwrap();
+        let expected = 10.4;
+
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
Added ability for matrices to be divided by scalars as well as a way for the min and max of Arr2D to be found.