### PR TITLE
feat: add `token_from_char` macro, organize unit tests  

### DIFF
--- a/spindalis_core/src/polynomials/ast.rs
+++ b/spindalis_core/src/polynomials/ast.rs
@@ -100,30 +100,6 @@ macro_rules! token_from_char {
     };
 }
 
-// #[derive(Debug, PartialEq)]
-// pub enum Operators {
-//     Add,
-//     Sub,
-//     Div,
-//     Mul,
-//     Rem,
-//     Caret,
-// }
-
-// impl Operators {
-//     pub fn from_char(c: char) -> Option<Self> {
-//         match c {
-//             '+' => Some(Operators::Add),
-//             '-' => Some(Operators::Sub),
-//             '*' => Some(Operators::Mul),
-//             '/' => Some(Operators::Div),
-//             '%' => Some(Operators::Rem),
-//             '^' => Some(Operators::Caret),
-//             _ => None,
-//         }
-//     }
-// }
-
 // declaring `Operators` with `token_from_char`
 token_from_char! {
     #[derive(Debug, PartialEq)]
@@ -137,32 +113,6 @@ token_from_char! {
     }
 }
 
-// #[derive(Debug, PartialEq)]
-// pub enum Functions {
-//     Sin,
-//     Cos,
-//     Tan,
-//     Cot,
-//     Log,
-//     Ln,
-// }
-
-// impl FromStr for Functions {
-//     type Err = ();
-
-//     fn from_str(s: &str) -> Result<Self, Self::Err> {
-//         match s.to_lowercase().as_str() {
-//             "sin" => Ok(Functions::Sin),
-//             "cos" => Ok(Functions::Cos),
-//             "tan" => Ok(Functions::Tan),
-//             "cot" => Ok(Functions::Cot),
-//             "log" => Ok(Functions::Log),
-//             "ln" => Ok(Functions::Ln),
-//             _ => Err(()),
-//         }
-//     }
-// }
-
 // declaring `Functions` with `token_from_str`
 token_from_str! {
     #[derive(Debug, PartialEq)]
@@ -175,28 +125,6 @@ token_from_str! {
         Ln => "ln",
     }
 }
-
-// #[derive(Debug, PartialEq)]
-// pub enum Constants {
-//     Pi,
-//     E,
-//     Tau,
-//     Phi,
-// }
-
-// impl FromStr for Constants {
-//     type Err = ();
-
-//     fn from_str(s: &str) -> Result<Self, Self::Err> {
-//         match s.to_lowercase().as_str() {
-//             "pi" => Ok(Constants::Pi),
-//             "e" => Ok(Constants::E),
-//             "tau" => Ok(Constants::Tau),
-//             "phi" => Ok(Constants::Phi),
-//             _ => Err(()),
-//         }
-//     }
-// }
 
 // declaring `Constants` with `token_from_str`
 token_from_str! {


### PR DESCRIPTION
closes https://github.com/lignum-vitae/spindalis/issues/23
follows up on https://github.com/lignum-vitae/spindalis/pull/58

cc: @dawnandrew100 
### This adds a `token_from_char!` macro to reduce boilerplate enum declaration and `from_char()` implementation, and unit tests
---
### 3 commits:

1. **adds `token_from_char!` macro.** **_changes the return type_** of the `from_char` function from `Option` to `Result` (https://github.com/lignum-vitae/spindalis/pull/58#issuecomment-3568018374)

2. **adds unit tests** for `token_from_char!` and organises both `token_from_char` and `token_from_str` unit test blocks. modifies an existing test to reflect the changed return type of `fn from_char`

3. **declares the existing `Operators` enum with `token_from_char!`** and makes minor modifications to some comments 
---
all tests pass:
<img width="669" height="142" alt="Screenshot 2025-11-24 at 16 59 38" src="https://github.com/user-attachments/assets/15ce8453-28ae-40f7-8769-474ad1df462b" />
