### PR TITLE
Add prelude

### DIFF
--- a/spindalis/examples/bisection.rs
+++ b/spindalis/examples/bisection.rs
@@ -1,5 +1,6 @@
-use spindalis::polynomials::{PolynomialTraits, SimplePolynomial};
-use spindalis::solvers::{Bounds, SolveMode, bisection};
+use spindalis::polynomials::SimplePolynomial;
+use spindalis::prelude::*;
+use spindalis::solvers::bisection;
 
 fn main() {
     let polynomial = "-2x^6 - 1.6x^4 + 12x + 1";

--- a/spindalis/examples/linear_regression.rs
+++ b/spindalis/examples/linear_regression.rs
@@ -1,4 +1,4 @@
-use spindalis::regressors::LinearRegressor;
+use spindalis::prelude::*;
 use spindalis::regressors::linear::{batch_validate_input, validate_single_input};
 use spindalis::regressors::{
     GradientDescentRegression, LeastSquaresRegression, PolynomialRegression,

--- a/spindalis/examples/nrm.rs
+++ b/spindalis/examples/nrm.rs
@@ -1,5 +1,6 @@
-use spindalis::polynomials::{PolynomialTraits, SimplePolynomial};
-use spindalis::solvers::{SolveMode, newton_raphson_method};
+use spindalis::polynomials::SimplePolynomial;
+use spindalis::prelude::*;
+use spindalis::solvers::newton_raphson_method;
 
 fn main() {
     let polynomial = "0.5x^3 - 3.9x^2 + 6x - 1.5";

--- a/spindalis/examples/polynomial_extended.rs
+++ b/spindalis/examples/polynomial_extended.rs
@@ -1,6 +1,7 @@
 use spindalis::derivatives::partial_derivative;
-use spindalis::polynomials::{IntermediatePolynomial, PolynomialTraits};
+use spindalis::polynomials::IntermediatePolynomial;
 use spindalis::polynomials::{eval_intermediate_polynomial, parse_intermediate_polynomial};
+use spindalis::prelude::*;
 
 #[allow(clippy::unnecessary_to_owned)]
 fn main() {

--- a/spindalis/examples/simple_polynomial.rs
+++ b/spindalis/examples/simple_polynomial.rs
@@ -1,5 +1,6 @@
+use spindalis::polynomials::SimplePolynomial;
 use spindalis::polynomials::parse_simple_polynomial;
-use spindalis::polynomials::{PolynomialTraits, SimplePolynomial};
+use spindalis::prelude::*;
 
 fn main() {
     let polynomial = "5a^3 + 4a^4 - 5a^2 + 1";

--- a/spindalis/examples/univariate_integrals.rs
+++ b/spindalis/examples/univariate_integrals.rs
@@ -1,5 +1,6 @@
 use spindalis::integrals::{analytical_integral, definite_integral, romberg_definite};
-use spindalis::polynomials::{IntermediatePolynomial, PolynomialTraits, SimplePolynomial};
+use spindalis::polynomials::{IntermediatePolynomial, SimplePolynomial};
+use spindalis::prelude::*;
 
 fn main() {
     // SIMPLE POLYNOMIALS

--- a/spindalis/src/lib.rs
+++ b/spindalis/src/lib.rs
@@ -6,6 +6,12 @@ pub mod regressors;
 pub mod solvers;
 pub mod utils;
 
+pub mod prelude {
+    pub use crate::polynomials::PolynomialTraits;
+    pub use crate::regressors::LinearRegressor;
+    pub use crate::solvers::{Bounds, SolveMode};
+}
+
 pub mod polynomials {
     pub use spindalis_core::polynomials as core;
     pub use spindalis_macros as macros;

--- a/spindalis/tests/test_analytical_integral.rs
+++ b/spindalis/tests/test_analytical_integral.rs
@@ -1,5 +1,6 @@
 use spindalis::integrals::analytical_integral;
-use spindalis::polynomials::{IntermediatePolynomial, PolynomialTraits, SimplePolynomial};
+use spindalis::polynomials::{IntermediatePolynomial, SimplePolynomial};
+use spindalis::prelude::*;
 
 #[test]
 fn test_analytical_integral_cubic() {

--- a/spindalis/tests/test_indefinite_integral.rs
+++ b/spindalis/tests/test_indefinite_integral.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use spindalis::polynomials::{IntermediatePolynomial, PolynomialTraits, SimplePolynomial};
+    use spindalis::polynomials::{IntermediatePolynomial, SimplePolynomial};
+    use spindalis::prelude::*;
 
     #[test]
     fn test_known_indefinite() {

--- a/spindalis/tests/test_simple_derivative.rs
+++ b/spindalis/tests/test_simple_derivative.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod tests {
     use spindalis::derivatives::simple_derivative;
-    use spindalis::polynomials::{PolynomialTraits, SimplePolynomial};
+    use spindalis::polynomials::SimplePolynomial;
+    use spindalis::prelude::*;
 
     #[test]
     fn test_derivative_simple() {

--- a/spindalis/tests/test_univariate_definite_integral.rs
+++ b/spindalis/tests/test_univariate_definite_integral.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod tests {
     use spindalis::integrals::{definite_integral, romberg_definite};
-    use spindalis::polynomials::{IntermediatePolynomial, PolynomialTraits, SimplePolynomial};
+    use spindalis::polynomials::{IntermediatePolynomial, SimplePolynomial};
+    use spindalis::prelude::*;
 
     #[test]
     fn test_known_solution_std_integral() {


### PR DESCRIPTION
Added a prelude module to expose commonly used traits and types through 
```rust
use spindalis::prelude::*.
```

This includes 
- PolynomialTraits, 
- SolveMode, 
- Bounds, 
- LinearRegressor.

Fixes  #85