### PR TITLE
feat: extend factorial_f64 to reals via Lanczos gamma

### DIFF
--- a/spindalis/src/lib.rs
+++ b/spindalis/src/lib.rs
@@ -6,6 +6,12 @@ pub mod regressors;
 pub mod solvers;
 pub mod utils;
 
+pub use spindalis_core::utils as core_util;
+// Utils
+pub use core_util::factorial::factorial_f64;
+pub use core_util::factorial::gamma_f64;
+pub use core_util::rounding::round_f64;
+
 pub mod prelude {
     pub use crate::polynomials::PolynomialTraits;
     pub use crate::regressors::LinearRegressor;
@@ -13,30 +19,30 @@ pub mod prelude {
 }
 
 pub mod polynomials {
-    pub use spindalis_core::polynomials as core;
+    pub use spindalis_core::polynomials as poly;
     pub use spindalis_macros as macros;
 
     // Component Structs
-    pub use core::Term;
-    pub use core::structs::PolynomialTraits;
+    pub use poly::Term;
+    pub use poly::structs::PolynomialTraits;
 
     // Polynomial Structs
-    pub use core::structs::IntermediatePolynomial;
-    pub use core::structs::Polynomial;
-    pub use core::structs::SimplePolynomial;
+    pub use poly::structs::IntermediatePolynomial;
+    pub use poly::structs::Polynomial;
+    pub use poly::structs::SimplePolynomial;
 
     // Error Enums
-    pub use core::PolynomialError;
+    pub use poly::PolynomialError;
 
     // Parsers and evaluators as functions
-    pub use core::advanced::eval_advanced_polynomial;
-    pub use core::advanced::lexer;
-    pub use core::advanced::parse_advanced_polynomial;
-    pub use core::intermediate::eval_intermediate_polynomial;
-    pub use core::intermediate::parse_intermediate_polynomial;
-    pub use core::simple::eval_simple_polynomial;
-    pub use core::simple::parse_simple_polynomial;
     pub use macros::{parse_intermediate_polynomial, parse_simple_polynomial};
+    pub use poly::advanced::eval_advanced_polynomial;
+    pub use poly::advanced::lexer;
+    pub use poly::advanced::parse_advanced_polynomial;
+    pub use poly::intermediate::eval_intermediate_polynomial;
+    pub use poly::intermediate::parse_intermediate_polynomial;
+    pub use poly::simple::eval_simple_polynomial;
+    pub use poly::simple::parse_simple_polynomial;
 }
 
 pub mod derivatives {

--- a/spindalis_core/src/lib.rs
+++ b/spindalis_core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod derivatives;
 pub mod integrals;
 pub mod polynomials;
+pub mod utils;

--- a/spindalis_core/src/polynomials/advanced.rs
+++ b/spindalis_core/src/polynomials/advanced.rs
@@ -1,5 +1,6 @@
 use crate::polynomials::PolynomialError;
 use crate::polynomials::structs::advanced::{Expr, Polynomial, TokenStream, Visitor};
+use crate::utils::factorial::factorial_f64;
 use std::collections::{BTreeSet, HashMap};
 use std::f64;
 use std::str::FromStr;
@@ -687,6 +688,16 @@ pub(crate) fn fold_operations(expr: Expr) -> Expr {
                     paren: false,
                 }),
 
+                // e^ln(x) = x
+                (
+                    Operators::Caret,
+                    Expr::Constant(Constants::E),
+                    Expr::Function {
+                        func: Functions::Ln | Functions::Log,
+                        inner: inner_value,
+                    },
+                ) => fold_operations(*inner_value),
+
                 // Variable exponent division: y^a / y^b -> 1, y^k, or 1/y^k
                 (Operators::Div, l, r) => {
                     let mut num_factors = Vec::new();
@@ -941,41 +952,6 @@ pub fn extract_univariate_variable(expr: &Expr) -> Result<String, PolynomialErro
     }
 }
 
-// Lanczos approximation of the gamma function (g = 7, 9 coefficients)
-fn gamma_f64(z: f64) -> f64 {
-    const G: f64 = 7.0;
-    const COEFFICIENTS: [f64; 9] = [
-        0.999_999_999_999_809_9,
-        676.520_368_121_885_1,
-        -1_259.139_216_722_402_8,
-        771.323_428_777_653_1,
-        -176.615_029_162_140_6,
-        12.507_343_278_686_905,
-        -0.138_571_095_265_720_12,
-        9.984_369_578_019_572e-6,
-        1.505_632_735_149_311_6e-7,
-    ];
-
-    let z = z - 1.0;
-    let series = COEFFICIENTS
-        .iter()
-        .enumerate()
-        .skip(1)
-        .fold(COEFFICIENTS[0], |acc, (i, c)| acc + c / (z + i as f64));
-    let t = z + G + 0.5;
-    (2.0 * f64::consts::PI).sqrt() * t.powf(z + 0.5) * (-t).exp() * series
-}
-
-fn factorial_f64(n: f64) -> f64 {
-    if n < 0.0 {
-        return f64::NAN;
-    }
-    if n.fract() != 0.0 {
-        return gamma_f64(n + 1.0);
-    }
-    let n_int = n.floor() as u64;
-    (1..=n_int).fold(1.0, |acc, x| acc * x as f64)
-}
 pub(crate) struct Evaluator;
 
 impl Visitor for Evaluator {
@@ -1059,6 +1035,7 @@ impl Visitor for Evaluator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::rounding::round_f64;
 
     // ---------------------------
     // Tokenizing tests
@@ -2067,32 +2044,164 @@ mod tests {
             let evaluated_result = poly.eval_multivariate(&[("x", 30)]).unwrap();
 
             let decimals = 6;
-            let rounded =
-                (evaluated_result * 10_f64.powi(decimals)).round() / 10_f64.powi(decimals);
+            let rounded = round_f64(evaluated_result, decimals);
             assert_eq!(rounded, 0.893997);
         }
+    }
+    // ---------------------------
+    // Test Folding
+    // ---------------------------
+    mod folding {
+        use super::*;
 
-        fn round_to(value: f64, decimals: i32) -> f64 {
-            (value * 10_f64.powi(decimals)).round() / 10_f64.powi(decimals)
+        #[test]
+        fn mul_0() {
+            let expr = "x * 0";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("0").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
         }
 
         #[test]
-        fn test_integer_factorial() {
-            assert_eq!(factorial_f64(0.0), 1.0);
-            assert_eq!(factorial_f64(5.0), 120.0);
+        fn mul_1() {
+            let expr = "x * 1";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
         }
 
         #[test]
-        fn test_non_integer_factorial() {
-            assert_eq!(round_to(factorial_f64(0.5), 4), 0.8862);
-            assert_eq!(round_to(factorial_f64(4.5), 4), 52.3428);
-            assert_eq!(round_to(factorial_f64(1.5), 4), 1.3293);
+        fn mul_0_1() {
+            let expr = "0 * 1";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("0").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
         }
 
         #[test]
-        fn test_negative_factorial() {
-            assert!(factorial_f64(-1.0).is_nan());
-            assert!(factorial_f64(-0.5).is_nan());
+        fn pow_x_0() {
+            let expr = "x^0";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("1").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn pow_x_1() {
+            let expr = "x^1";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn sub_x_0() {
+            let expr = "x - 0";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn sub_0_x() {
+            let expr = "0 - x";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("-x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn div_x_1() {
+            let expr = "x/1";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn three_div_x_div_y() {
+            let expr = "3/x/y";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("3y/x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn e_power_of_ln() {
+            let expr = "e^ln(x)";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn e_power_of_ln_3x_pow_0() {
+            let expr = "e^ln(3x^0)";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("3").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn arithmetic() {
+            let expr = "2+4*10-6/2";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("39").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn div_exponents() {
+            let expr = "y^3/y^3";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("1").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn div_exponents_2() {
+            let expr = "y^4/y^3";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("y").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
+        }
+
+        #[test]
+        fn div_exponents_multivar() {
+            let expr = "y^4/(xy^3)";
+            let poly = Polynomial::parse(expr).unwrap();
+            let folded = fold_operations(poly.expr);
+            let expected = Polynomial::parse("y/x").unwrap();
+
+            assert_eq!(Polynomial { expr: folded }, expected);
         }
     }
     // ---------------------------

--- a/spindalis_core/src/polynomials/advanced.rs
+++ b/spindalis_core/src/polynomials/advanced.rs
@@ -941,9 +941,37 @@ pub fn extract_univariate_variable(expr: &Expr) -> Result<String, PolynomialErro
     }
 }
 
+// Lanczos approximation of the gamma function (g = 7, 9 coefficients)
+fn gamma_f64(z: f64) -> f64 {
+    const G: f64 = 7.0;
+    const COEFFICIENTS: [f64; 9] = [
+        0.999_999_999_999_809_9,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_8,
+        771.323_428_777_653_1,
+        -176.615_029_162_140_6,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_572e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+
+    let z = z - 1.0;
+    let series = COEFFICIENTS
+        .iter()
+        .enumerate()
+        .skip(1)
+        .fold(COEFFICIENTS[0], |acc, (i, c)| acc + c / (z + i as f64));
+    let t = z + G + 0.5;
+    (2.0 * f64::consts::PI).sqrt() * t.powf(z + 0.5) * (-t).exp() * series
+}
+
 fn factorial_f64(n: f64) -> f64 {
     if n < 0.0 {
         return f64::NAN;
+    }
+    if n.fract() != 0.0 {
+        return gamma_f64(n + 1.0);
     }
     let n_int = n.floor() as u64;
     (1..=n_int).fold(1.0, |acc, x| acc * x as f64)
@@ -2042,6 +2070,29 @@ mod tests {
             let rounded =
                 (evaluated_result * 10_f64.powi(decimals)).round() / 10_f64.powi(decimals);
             assert_eq!(rounded, 0.893997);
+        }
+
+        fn round_to(value: f64, decimals: i32) -> f64 {
+            (value * 10_f64.powi(decimals)).round() / 10_f64.powi(decimals)
+        }
+
+        #[test]
+        fn test_integer_factorial() {
+            assert_eq!(factorial_f64(0.0), 1.0);
+            assert_eq!(factorial_f64(5.0), 120.0);
+        }
+
+        #[test]
+        fn test_non_integer_factorial() {
+            assert_eq!(round_to(factorial_f64(0.5), 4), 0.8862);
+            assert_eq!(round_to(factorial_f64(4.5), 4), 52.3428);
+            assert_eq!(round_to(factorial_f64(1.5), 4), 1.3293);
+        }
+
+        #[test]
+        fn test_negative_factorial() {
+            assert!(factorial_f64(-1.0).is_nan());
+            assert!(factorial_f64(-0.5).is_nan());
         }
     }
     // ---------------------------

--- a/spindalis_core/src/utils/factorial.rs
+++ b/spindalis_core/src/utils/factorial.rs
@@ -1,0 +1,80 @@
+use std::f64;
+
+// Lanczos approximation of the gamma function (g = 7, 9 coefficients)
+// Source: https://grokipedia.com/page/Lanczos_approximation
+pub fn gamma_f64(z: f64) -> f64 {
+    const G: f64 = 7.0;
+    const COEFFICIENTS: [f64; 9] = [
+        0.999_999_999_999_809_9,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_8,
+        771.323_428_777_653_1,
+        -176.615_029_162_140_6,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_572e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+
+    let z = z - 1.;
+    let series = COEFFICIENTS
+        .iter()
+        .enumerate()
+        .skip(1)
+        .fold(COEFFICIENTS[0], |acc, (i, c)| acc + c / (z + i as f64));
+    let t = z + G + 0.5;
+    let log_gamma = ((2.0 * f64::consts::PI).sqrt()).ln() + (z + 0.5) * t.ln() - t + series.ln();
+
+    log_gamma.exp()
+}
+
+pub fn factorial_f64(n: f64) -> f64 {
+    if n < 0.0 {
+        return f64::NAN;
+    }
+    if n.fract() != 0.0 {
+        return gamma_f64(n + 1.); // Gamma(n+1) = n!
+    }
+    (1..=n as u64).fold(1.0, |acc, x| acc * x as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::rounding::round_f64;
+
+    #[test]
+    fn test_integer_factorial_1() {
+        assert_eq!(factorial_f64(0.0), 1.0);
+    }
+
+    #[test]
+    fn test_integer_factorial_2() {
+        assert_eq!(factorial_f64(5.0), 120.0);
+    }
+
+    #[test]
+    fn test_non_integer_factorial_1() {
+        assert_eq!(round_f64(factorial_f64(0.5), 4), 0.8862);
+    }
+
+    #[test]
+    fn test_non_integer_factorial_2() {
+        assert_eq!(round_f64(factorial_f64(4.5), 4), 52.3428);
+    }
+
+    #[test]
+    fn test_non_integer_factorial_3() {
+        assert_eq!(round_f64(factorial_f64(1.5), 4), 1.3293);
+    }
+
+    #[test]
+    fn test_negative_factorial_1() {
+        assert!(factorial_f64(-1.0).is_nan());
+    }
+
+    #[test]
+    fn test_negative_factorial_2() {
+        assert!(factorial_f64(-0.5).is_nan());
+    }
+}

--- a/spindalis_core/src/utils/mod.rs
+++ b/spindalis_core/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod factorial;
+pub mod rounding;

--- a/spindalis_core/src/utils/rounding.rs
+++ b/spindalis_core/src/utils/rounding.rs
@@ -1,0 +1,3 @@
+pub fn round_f64(value: f64, decimals: i32) -> f64 {
+    (value * 10_f64.powi(decimals)).round() / 10_f64.powi(decimals)
+}


### PR DESCRIPTION
factorial_f64 floored its input, so 4.5! returned 4! = 24. This routes non-integer inputs through Γ(n+1) instead.

Added a gamma_f64 helper using the Lanczos approximation (g=7, 9 coefficients). Integer path is unchanged so integer factorials stay exact and existing tests pass. Negatives still return NaN. Gamma only ever sees z ≥ 1 (negatives are rejected before it's called), so I skipped the reflection formula.

Checked there was no existing gamma in the file first — the only Gamma hits were an unrelated enum variant.

Tests added to test_eval: integer, a few non-integers (0.5, 4.5, 1.5), and the negative-NaN case. just check passes clean.

Closes #96 