### PR TITLE
Francis decomposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,76 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
+
+[[package]]
 name = "jedvek"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2232a3f00adf995e24af3f0d768e2037b3dcc4905244f412848476dc697db441"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -27,10 +93,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "spindalis"
 version = "0.6.0"
 dependencies = [
  "jedvek",
+ "rand",
+ "rand_distr",
  "spindalis_core",
  "spindalis_macros",
 ]

--- a/spindalis/Cargo.toml
+++ b/spindalis/Cargo.toml
@@ -18,3 +18,7 @@ path = "src/lib.rs"
 jedvek = "0.2.0"
 spindalis_core = { path = "../spindalis_core", version = ">=0.2.0" }
 spindalis_macros = { path = "../spindalis_macros", version = "0.1.0" }
+
+[dev-dependencies]
+rand = "0.10.0"
+rand_distr = "0.6.0"

--- a/spindalis/src/reduction/matrix/francis/complex.rs
+++ b/spindalis/src/reduction/matrix/francis/complex.rs
@@ -1,6 +1,6 @@
-use crate::decomposition::sgivens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+use crate::reduction::matrix::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
 #[rustfmt::skip]
-use crate::decomposition::francis::primitives::{
+use crate::reduction::matrix::francis::primitives::{
     params,
     deflate,
     eigen,
@@ -11,13 +11,13 @@ use crate::decomposition::francis::primitives::{
     rapply_householder,
 };
 pub fn decomp_cpx(
-    h: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    w: &mut [f64],
     mut range: usize,
     size: usize,
     stride: usize,
     max_iters: usize,
-    tolerance: f32,
+    tolerance: f64,
 ) {
     let s = range * stride;
     // error 1 supra-diagonal above the first real eigen
@@ -26,7 +26,7 @@ pub fn decomp_cpx(
     let mut e2 = s.saturating_sub(stride + stride + 2);
     let mut tl = s.saturating_sub(stride + 2);
     let mut bl = s.saturating_sub(2);
-    let p = &mut [0f32; 3];
+    let p = &mut [0f64; 3];
     let mut curriter = 0;
     let mut stall = 0;
     while range > 0 && curriter < max_iters {
@@ -92,9 +92,9 @@ pub fn decomp_cpx(
 /// * range: number of rows in active window
 /// * stride: stride of the data format
 pub fn francis_iteration_cpx(
-    h: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
     size: usize,
     range: usize,
     stride: usize,
@@ -102,7 +102,7 @@ pub fn francis_iteration_cpx(
     let bound = range.min(3);
     let p = &mut p[..bound];
     let tau = params(&mut w[..bound], p);
-    if tau != 0f32 {
+    if tau != 0f64 {
         rapply_householder(h, p, w, tau, size, bound, stride);
         lapply_householder(h, p, w, tau, bound, range, stride);
     }
@@ -114,7 +114,7 @@ pub fn francis_iteration_cpx(
         let proj = &mut p[..bound];
         let tau = params(slice, proj);
         offset += stride;
-        if tau == 0f32 {
+        if tau == 0f64 {
             continue;
         }
         rapply_householder(&mut t[o..], proj, w, tau, size - o, bound, stride);
@@ -129,7 +129,7 @@ pub fn francis_iteration_cpx(
 /// * stride: stride of the data format
 /// * tl : top-left of the eigen-pair
 /// * bl : bottom-left of the eigen-pair
-pub fn francis_iteration_cpx_2x2(h: &mut [f32], size: usize, stride: usize, tl: usize, bl: usize) {
+pub fn francis_iteration_cpx_2x2(h: &mut [f64], size: usize, stride: usize, tl: usize, bl: usize) {
     let eig = eigen(h[tl], h[tl + 1], h[bl], h[bl + 1]);
     let (_, cosine, sine) = implicit_givens_rotation(h[0] - eig, h[1]);
     apply_gt_right(h, 0, 1, stride, size, cosine, sine);

--- a/spindalis/src/reduction/matrix/francis/complex.rs
+++ b/spindalis/src/reduction/matrix/francis/complex.rs
@@ -1,4 +1,6 @@
-use crate::reduction::matrix::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+use crate::reduction::matrix::francis::givens::{
+    apply_g_left, apply_gt_right, implicit_givens_rotation,
+};
 #[rustfmt::skip]
 use crate::reduction::matrix::francis::primitives::{
     params,

--- a/spindalis/src/reduction/matrix/francis/complex.rs
+++ b/spindalis/src/reduction/matrix/francis/complex.rs
@@ -1,0 +1,137 @@
+use crate::decomposition::sgivens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+#[rustfmt::skip]
+use crate::decomposition::francis::primitives::{
+    params,
+    deflate,
+    eigen,
+    double_shift,
+    exception_shift,
+    complex_eig_pair,
+    lapply_householder,
+    rapply_householder,
+};
+pub fn decomp_cpx(
+    h: &mut [f32],
+    w: &mut [f32],
+    mut range: usize,
+    size: usize,
+    stride: usize,
+    max_iters: usize,
+    tolerance: f32,
+) {
+    let s = range * stride;
+    // error 1 supra-diagonal above the first real eigen
+    // error 2 supra-diagonal above the second complex real eigen
+    let mut e1 = s.saturating_sub(stride + 1);
+    let mut e2 = s.saturating_sub(stride + stride + 2);
+    let mut tl = s.saturating_sub(stride + 2);
+    let mut bl = s.saturating_sub(2);
+    let p = &mut [0f32; 3];
+    let mut curriter = 0;
+    let mut stall = 0;
+    while range > 0 && curriter < max_iters {
+        curriter += 1;
+        if h[e1].abs() < tolerance {
+            stall = 0;
+            deflate(
+                1,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+        } else if h[e2].abs() < tolerance {
+            // if e2 == 0 then we are hitting eigen which should be greater than tolerance
+            deflate(
+                2,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+            stall = 0;
+        } else if range == 2 && complex_eig_pair(h, tl, bl) {
+            deflate(
+                2,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+            stall = 0;
+        } else {
+            if range == 2 {
+                francis_iteration_cpx_2x2(h, size, stride, tl, bl);
+            } else if (stall + 8) % 12 == 0 {
+                exception_shift(h, w, stride, range, tl, bl);
+                francis_iteration_cpx(h, p, w, size, range, stride);
+            } else {
+                double_shift(h, w, stride, range, tl, bl);
+                francis_iteration_cpx(h, p, w, size, range, stride);
+            }
+            stall += 1;
+        }
+    }
+}
+/// francis_iteration_cpx
+///
+/// * h: hessenberg linearized matrix
+/// * r: rotaiton linearized matrix
+/// * p: projection slice
+/// * w: workspace slice
+/// * size: static number of rows for rotations
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+pub fn francis_iteration_cpx(
+    h: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    size: usize,
+    range: usize,
+    stride: usize,
+) {
+    let bound = range.min(3);
+    let p = &mut p[..bound];
+    let tau = params(&mut w[..bound], p);
+    if tau != 0f32 {
+        rapply_householder(h, p, w, tau, size, bound, stride);
+        lapply_householder(h, p, w, tau, bound, range, stride);
+    }
+    let mut offset = 0;
+    for o in 1..range.saturating_sub(1) {
+        let bound = bound.min(stride - o);
+        let (slice, t) = h.split_at_mut(offset + stride);
+        let slice = &mut slice[offset + o..offset + o + bound];
+        let proj = &mut p[..bound];
+        let tau = params(slice, proj);
+        offset += stride;
+        if tau == 0f32 {
+            continue;
+        }
+        rapply_householder(&mut t[o..], proj, w, tau, size - o, bound, stride);
+        lapply_householder(&mut h[offset..], proj, w, tau, bound, range, stride);
+    }
+}
+/// francis_iteration_cpx_2x2
+///
+/// * h: hessenberg linearized matrix
+/// * size: static number of rows for rotations
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+/// * tl : top-left of the eigen-pair
+/// * bl : bottom-left of the eigen-pair
+pub fn francis_iteration_cpx_2x2(h: &mut [f32], size: usize, stride: usize, tl: usize, bl: usize) {
+    let eig = eigen(h[tl], h[tl + 1], h[bl], h[bl + 1]);
+    let (_, cosine, sine) = implicit_givens_rotation(h[0] - eig, h[1]);
+    apply_gt_right(h, 0, 1, stride, size, cosine, sine);
+    apply_g_left(h, 0, 1, stride, 2, cosine, sine);
+}

--- a/spindalis/src/reduction/matrix/francis/constants.rs
+++ b/spindalis/src/reduction/matrix/francis/constants.rs
@@ -1,0 +1,33 @@
+// ============================================================================
+// Francis QR Algorithm Parameters & Tuning Constants
+// ============================================================================
+
+/// **Primary Production Profile** (Success Rate: ~99.98% on test suites)
+///
+/// - **`MAX_ITERS` (16):** Upper bound on iterations per active window.
+///   Successfully achieving deflation "refunds" half of these iterations
+///   (`curriter = curriter.saturating_sub(MAX_ITERS >> 1)`), preventing
+///   stalls from penalizing subsequent windows.
+///
+/// - **`TOLERANCE` (1e-4) & `ABSOLUTE_CAP` (1e-3):** Tuned specifically for
+///   approximate symmetric matrices (e.g., those generated via $AA^T$).
+///   Single-precision (`f32`) rounding error in $AA^T$ constructions prevents
+///   stricter convergence.
+///   *(Note: While diagonal averaging/rectification could theoretically clean up
+///   minor symmetry drift prior to decomposition, it is generally cleaner to
+///   handle this via a slightly relaxed absolute floor like `1e-3` here).*
+///
+/// - **`EPSILON` (1e-18):** Numerical floor guarding against division-by-zero
+///   and negligible subdiagonal elements during Householder/Givens setups.
+pub const MAX_ITERS: usize = 16;
+pub const TOLERANCE: f32 = 1e-4;
+pub const ABSOLUTE_CAP: f32 = 1e-3;
+pub const EPSILON: f32 = 1e-21;
+
+// // -------------------------------------------------------------------------
+// // **Strict Precision Profile** (Alternative for high-precision synthetic inputs)
+// // -------------------------------------------------------------------------
+// pub const MAX_ITERS: usize = 24;
+// pub const TOLERANCE: f32 = 1e-8;
+// pub const ABSOLUTE_CAP: f32 = 1e-6; // Recommended companion adjustment if strict
+// pub const EPSILON: f32 = 1e-26;

--- a/spindalis/src/reduction/matrix/francis/constants.rs
+++ b/spindalis/src/reduction/matrix/francis/constants.rs
@@ -11,7 +11,7 @@
 ///
 /// - **`TOLERANCE` (1e-4) & `ABSOLUTE_CAP` (1e-3):** Tuned specifically for
 ///   approximate symmetric matrices (e.g., those generated via $AA^T$).
-///   Single-precision (`f32`) rounding error in $AA^T$ constructions prevents
+///   Single-precision (`f64`) rounding error in $AA^T$ constructions prevents
 ///   stricter convergence.
 ///   *(Note: While diagonal averaging/rectification could theoretically clean up
 ///   minor symmetry drift prior to decomposition, it is generally cleaner to
@@ -20,14 +20,14 @@
 /// - **`EPSILON` (1e-18):** Numerical floor guarding against division-by-zero
 ///   and negligible subdiagonal elements during Householder/Givens setups.
 pub const MAX_ITERS: usize = 16;
-pub const TOLERANCE: f32 = 1e-4;
-pub const ABSOLUTE_CAP: f32 = 1e-3;
-pub const EPSILON: f32 = 1e-21;
+pub const TOLERANCE: f64 = 1e-4;
+pub const ABSOLUTE_CAP: f64 = 1e-3;
+pub const EPSILON: f64 = 1e-21;
 
 // // -------------------------------------------------------------------------
 // // **Strict Precision Profile** (Alternative for high-precision synthetic inputs)
 // // -------------------------------------------------------------------------
 // pub const MAX_ITERS: usize = 24;
-// pub const TOLERANCE: f32 = 1e-8;
-// pub const ABSOLUTE_CAP: f32 = 1e-6; // Recommended companion adjustment if strict
-// pub const EPSILON: f32 = 1e-26;
+// pub const TOLERANCE: f64 = 1e-8;
+// pub const ABSOLUTE_CAP: f64 = 1e-6; // Recommended companion adjustment if strict
+// pub const EPSILON: f64 = 1e-26;

--- a/spindalis/src/reduction/matrix/francis/givens.rs
+++ b/spindalis/src/reduction/matrix/francis/givens.rs
@@ -1,37 +1,37 @@
-pub fn implicit_givens_rotation(a: f32, b: f32) -> (f32, f32, f32) {
-    let t: f32;
-    let tt: f32;
-    let s: f32;
-    let c: f32;
-    let r: f32;
+pub fn implicit_givens_rotation(a: f64, b: f64) -> (f64, f64, f64) {
+    let t: f64;
+    let tt: f64;
+    let s: f64;
+    let c: f64;
+    let r: f64;
 
-    if a == 0f32 {
-        c = 0f32;
-        s = 1f32;
+    if a == 0f64 {
+        c = 0f64;
+        s = 1f64;
         r = b;
     } else if b.abs() > a.abs() {
         t = a / b;
-        tt = (1f32 + t * t).sqrt();
-        s = 1f32 / tt;
+        tt = (1f64 + t * t).sqrt();
+        s = 1f64 / tt;
         c = s * t;
         r = b * tt;
     } else {
         t = b / a;
-        tt = (1f32 + t * t).sqrt();
-        c = 1f32 / tt;
+        tt = (1f64 + t * t).sqrt();
+        c = 1f64 / tt;
         s = c * t;
         r = a * tt;
     }
     (r, c, s)
 }
 pub fn apply_g_left(
-    a: &mut [f32],
+    a: &mut [f64],
     i: usize,
     j: usize,
     stride: usize,
     range: usize,
-    c: f32,
-    s: f32,
+    c: f64,
+    s: f64,
 ) {
     // G * A
     // alpha, beta, gamma, delta,
@@ -49,13 +49,13 @@ pub fn apply_g_left(
     }
 }
 pub fn apply_gt_left(
-    a: &mut [f32],
+    a: &mut [f64],
     i: usize,
     j: usize,
     stride: usize,
     range: usize,
-    c: f32,
-    s: f32,
+    c: f64,
+    s: f64,
 ) {
     // G' * A
     // transpose the negative sine
@@ -73,13 +73,13 @@ pub fn apply_gt_left(
     }
 }
 pub fn apply_g_right(
-    a: &mut [f32],
+    a: &mut [f64],
     i: usize,
     j: usize,
     stride: usize,
     range: usize,
-    c: f32,
-    s: f32,
+    c: f64,
+    s: f64,
 ) {
     // A * G
     // alpha, beta, gamma, delta,
@@ -96,13 +96,13 @@ pub fn apply_g_right(
     }
 }
 pub fn apply_gt_right(
-    a: &mut [f32],
+    a: &mut [f64],
     i: usize,
     j: usize,
     stride: usize,
     range: usize,
-    c: f32,
-    s: f32,
+    c: f64,
+    s: f64,
 ) {
     // A * G'
     // alpha, beta, gamma, delta,

--- a/spindalis/src/reduction/matrix/francis/givens.rs
+++ b/spindalis/src/reduction/matrix/francis/givens.rs
@@ -1,0 +1,119 @@
+pub fn implicit_givens_rotation(a: f32, b: f32) -> (f32, f32, f32) {
+    let t: f32;
+    let tt: f32;
+    let s: f32;
+    let c: f32;
+    let r: f32;
+
+    if a == 0f32 {
+        c = 0f32;
+        s = 1f32;
+        r = b;
+    } else if b.abs() > a.abs() {
+        t = a / b;
+        tt = (1f32 + t * t).sqrt();
+        s = 1f32 / tt;
+        c = s * t;
+        r = b * tt;
+    } else {
+        t = b / a;
+        tt = (1f32 + t * t).sqrt();
+        c = 1f32 / tt;
+        s = c * t;
+        r = a * tt;
+    }
+    (r, c, s)
+}
+pub fn apply_g_left(
+    a: &mut [f32],
+    i: usize,
+    j: usize,
+    stride: usize,
+    range: usize,
+    c: f32,
+    s: f32,
+) {
+    // G * A
+    // alpha, beta, gamma, delta,
+    // c, s, -s, c
+    // let (m, n) = (a.dims[0], a.dims[1]);
+    for k in 0..range {
+        let r1 = i * stride;
+        let r2 = j * stride;
+        // alpha a[i*,k] + beta a[j*, k];
+        let i_replace = c * a[r1 + k] + s * a[r2 + k];
+        // gamma a[i*,k] + delta a[j*, k];
+        let j_replace = -s * a[r1 + k] + c * a[r2 + k];
+        a[r1 + k] = i_replace;
+        a[r2 + k] = j_replace;
+    }
+}
+pub fn apply_gt_left(
+    a: &mut [f32],
+    i: usize,
+    j: usize,
+    stride: usize,
+    range: usize,
+    c: f32,
+    s: f32,
+) {
+    // G' * A
+    // transpose the negative sine
+    // alpha, beta, gamma, delta,
+    // c, -s, s, c
+    let r1 = i * stride;
+    let r2 = j * stride;
+    for k in 0..range {
+        // alpha a[i*,j] + beta a[j*, j];
+        let i_replace = c * a[r1 + k] - s * a[r2 + k];
+        // gamma a[i*,j] + delta a[j*, j];
+        let j_replace = s * a[r1 + k] + c * a[r2 + k];
+        a[r1 + k] = i_replace;
+        a[r2 + k] = j_replace;
+    }
+}
+pub fn apply_g_right(
+    a: &mut [f32],
+    i: usize,
+    j: usize,
+    stride: usize,
+    range: usize,
+    c: f32,
+    s: f32,
+) {
+    // A * G
+    // alpha, beta, gamma, delta,
+    // c, s, -s, c
+    let mut r = 0;
+    for _ in 0..range {
+        // alpha a[l,i*] + gamma a[l, j*];
+        let i_replace = c * a[r + i] - s * a[r + j];
+        // beta a[l,i*] + delta a[l, j*];
+        let j_replace = s * a[r + i] + c * a[r + j];
+        a[r + i] = i_replace;
+        a[r + j] = j_replace;
+        r += stride;
+    }
+}
+pub fn apply_gt_right(
+    a: &mut [f32],
+    i: usize,
+    j: usize,
+    stride: usize,
+    range: usize,
+    c: f32,
+    s: f32,
+) {
+    // A * G'
+    // alpha, beta, gamma, delta,
+    // c, -s, s, c
+    for l in 0..range {
+        let r = l * stride;
+        // alpha a[l,i*] + gamma a[l, j*];
+        let i_replace = c * a[r + i] + s * a[r + j];
+        // beta a[l,i*] + delta a[l, j*];
+        let j_replace = -s * a[r + i] + c * a[r + j];
+        a[r + i] = i_replace;
+        a[r + j] = j_replace;
+    }
+}

--- a/spindalis/src/reduction/matrix/francis/interface.rs
+++ b/spindalis/src/reduction/matrix/francis/interface.rs
@@ -1,4 +1,4 @@
-use crate::decomposition::francis::{complex, primitives, symmetric};
+use crate::reduction::matrix::francis::{complex, primitives, symmetric};
 
 // Recommended parameters in constants
 // Note: For real-world inputs like A^T*A covariance matrices, explicit forming
@@ -16,15 +16,15 @@ use crate::decomposition::francis::{complex, primitives, symmetric};
 /// * tolerance: error tolerance which is used as a bound for non relative error
 /// * absolute: absolute bound on error minimum should be less than tolerance
 pub fn francis_qr_sym(
-    h: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
     range: usize,
     size: usize,
     stride: usize,
     max_iters: usize,
-    tolerance: f32,
-    absolute: f32,
+    tolerance: f64,
+    absolute: f64,
 ) {
     primitives::hessenberg(h, p, w, size, range, stride);
     symmetric::decomp_sym(h, range, size, stride, max_iters, tolerance, absolute);
@@ -39,34 +39,94 @@ pub fn francis_qr_sym(
 /// * max_iters: number of iterations per eigen vector recoups half on success
 /// * tolerance: error tolerance which is used as a bound for non relative error
 pub fn francis_qr_cpx(
-    h: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
     range: usize,
     size: usize,
     stride: usize,
     max_iters: usize,
-    tolerance: f32,
+    tolerance: f64,
 ) {
     primitives::hessenberg(h, p, w, size, range, stride);
     complex::decomp_cpx(h, w, range, size, stride, max_iters, tolerance);
 }
-
+#[cfg(test)]
 mod test_francis_interface {
     use super::*;
 
-    use crate::decomposition::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
-    use crate::equality::approximate::approx_scalar_eq;
-    use crate::random::generation::{generate_approx_symmetric_vector, generate_random_vector};
-    fn trace(data: &[f32], n: usize, stride: usize) -> f32 {
+    use crate::reduction::matrix::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
+    use rand::prelude::*;
+
+    use rand_distr::StandardNormal;
+    fn approx_scalar_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < TOLERANCE
+    }
+    fn approx_vector_eq(a: &[f64], b: &[f64]) -> bool {
+        let n = a.len();
+        let mut error = 0f64;
+        for i in 0..n {
+            if a[i].is_nan() || b[i].is_nan() {
+                return false;
+            }
+            error += (a[i] - b[i]).abs();
+        }
+        error / (n as f64).sqrt() < TOLERANCE
+    }
+    //  NOTE: This should also be weighted towards the size of the dimensionality
+    //  of the decomposition ie the condition number not a flat tolerance level
+    fn generate_random_vector(n: usize) -> Vec<f64> {
+        let mut rng = rand::rng();
+        let mut data = vec![0f64; n];
+        for i in 0..n {
+            data[i] = rng.sample(StandardNormal);
+        }
+        data
+    }
+    fn generate_identity_vector(m: usize, n: usize) -> Vec<f64> {
+        let mut vector = vec![0f64; m * n];
+        let mut idx = 0;
+        for _ in 0..m {
+            vector[idx] = 1f64;
+            idx += 1 + n;
+        }
+        vector
+    }
+    fn generate_strict_symmetric_vector(n: usize) -> Vec<f64> {
+        let mut data = generate_random_vector(n * n);
+        for i in 0..n {
+            for j in 0..i {
+                let val = data[i * n + j];
+                data[j * n + i] = val;
+            }
+        }
+        data
+    }
+    /// Creates some f64 style noise in order to replicate working with matrices
+    pub fn generate_approx_symmetric_vector(n: usize) -> Vec<f64> {
+        let a = generate_random_vector(n * n); // flat, row-major, stride = n
+        let mut result = vec![0f64; n * n];
+        for i in 0..n {
+            for j in 0..n {
+                let mut sum = 0f64;
+                for k in 0..n {
+                    // A[i][k] * A[j][k]  ==  (A * A^T)[i][j]
+                    sum += a[i * n + k] * a[j * n + k];
+                }
+                result[i * n + j] = sum;
+            }
+        }
+        result
+    }
+    fn trace(data: &[f64], n: usize, stride: usize) -> f64 {
         (0..n).map(|i| data[i * stride + i]).sum()
     }
     fn check_francis_qr_sym() -> (bool, bool) {
         let c = 6;
         let stride = c;
         let mut h = generate_approx_symmetric_vector(c);
-        let mut p = vec![0f32; c];
-        let mut w = vec![0f32; c];
+        let mut p = vec![0f64; c];
+        let mut w = vec![0f64; c];
 
         let original_trace = trace(&h, c, stride);
 
@@ -90,8 +150,8 @@ mod test_francis_interface {
         let c = 6;
         let stride = c;
         let mut h = generate_random_vector(c * c);
-        let mut p = vec![0f32; c];
-        let mut w = vec![0f32; c];
+        let mut p = vec![0f64; c];
+        let mut w = vec![0f64; c];
 
         let original_trace = trace(&h, c, stride);
 

--- a/spindalis/src/reduction/matrix/francis/interface.rs
+++ b/spindalis/src/reduction/matrix/francis/interface.rs
@@ -1,4 +1,61 @@
 use crate::reduction::matrix::francis::{complex, primitives, symmetric};
+use crate::solvers::SolverError;
+use jedvek::Matrix2D;
+
+const DEFAULT_MAX_ITERS: usize = 100;
+const DEFAULT_TOLERANCE: f64 = 1e-10;
+const DEFAULT_ABSOLUTE: f64 = 1e-12;
+
+pub fn auto_francis_qr_sym(matrix: &Matrix2D<f64>) -> Result<Matrix2D<f64>, SolverError> {
+    if matrix.height != matrix.width {
+        return Err(SolverError::NonSquareMatrix);
+    }
+    let n = matrix.height;
+    let stride = n;
+
+    let mut h: Vec<f64> = matrix.rows().flatten().copied().collect();
+    let mut p = vec![0f64; n];
+    let mut w = vec![0f64; n];
+
+    francis_qr_sym(
+        &mut h,
+        &mut p,
+        &mut w,
+        n,
+        n,
+        stride,
+        DEFAULT_MAX_ITERS,
+        DEFAULT_TOLERANCE,
+        DEFAULT_ABSOLUTE,
+    );
+
+    Matrix2D::from_flat(h, 0.0, n, n).map_err(SolverError::InvalidVector)
+}
+
+pub fn auto_francis_qr_cpx(matrix: &Matrix2D<f64>) -> Result<Matrix2D<f64>, SolverError> {
+    if matrix.height != matrix.width {
+        return Err(SolverError::NonSquareMatrix);
+    }
+    let n = matrix.height;
+    let stride = n;
+
+    let mut h: Vec<f64> = matrix.rows().flatten().copied().collect();
+    let mut p = vec![0f64; n];
+    let mut w = vec![0f64; n];
+
+    francis_qr_cpx(
+        &mut h,
+        &mut p,
+        &mut w,
+        n,
+        n,
+        stride,
+        DEFAULT_MAX_ITERS,
+        DEFAULT_TOLERANCE,
+    );
+
+    Matrix2D::from_flat(h, 0.0, n, n).map_err(SolverError::InvalidVector)
+}
 
 // Recommended parameters in constants
 // Note: For real-world inputs like A^T*A covariance matrices, explicit forming
@@ -62,19 +119,6 @@ mod test_francis_interface {
     fn approx_scalar_eq(a: f64, b: f64) -> bool {
         (a - b).abs() < TOLERANCE
     }
-    fn approx_vector_eq(a: &[f64], b: &[f64]) -> bool {
-        let n = a.len();
-        let mut error = 0f64;
-        for i in 0..n {
-            if a[i].is_nan() || b[i].is_nan() {
-                return false;
-            }
-            error += (a[i] - b[i]).abs();
-        }
-        error / (n as f64).sqrt() < TOLERANCE
-    }
-    //  NOTE: This should also be weighted towards the size of the dimensionality
-    //  of the decomposition ie the condition number not a flat tolerance level
     fn generate_random_vector(n: usize) -> Vec<f64> {
         let mut rng = rand::rng();
         let mut data = vec![0f64; n];
@@ -83,27 +127,8 @@ mod test_francis_interface {
         }
         data
     }
-    fn generate_identity_vector(m: usize, n: usize) -> Vec<f64> {
-        let mut vector = vec![0f64; m * n];
-        let mut idx = 0;
-        for _ in 0..m {
-            vector[idx] = 1f64;
-            idx += 1 + n;
-        }
-        vector
-    }
-    fn generate_strict_symmetric_vector(n: usize) -> Vec<f64> {
-        let mut data = generate_random_vector(n * n);
-        for i in 0..n {
-            for j in 0..i {
-                let val = data[i * n + j];
-                data[j * n + i] = val;
-            }
-        }
-        data
-    }
     /// Creates some f64 style noise in order to replicate working with matrices
-    pub fn generate_approx_symmetric_vector(n: usize) -> Vec<f64> {
+    fn generate_approx_symmetric_vector(n: usize) -> Vec<f64> {
         let a = generate_random_vector(n * n); // flat, row-major, stride = n
         let mut result = vec![0f64; n * n];
         for i in 0..n {

--- a/spindalis/src/reduction/matrix/francis/interface.rs
+++ b/spindalis/src/reduction/matrix/francis/interface.rs
@@ -1,0 +1,137 @@
+use crate::decomposition::francis::{complex, primitives, symmetric};
+
+// Recommended parameters in constants
+// Note: For real-world inputs like A^T*A covariance matrices, explicit forming
+// squares condition numbers, so a pre-QR step or an explicit symmetrization
+// pass on the tridiagonal output can help keep float drift in check.
+
+/// francis_qr_sym
+///
+/// * h: householder
+/// * p: projection vector
+/// * w: workspace for a givens rotation
+/// * range: number of rows in active window
+/// * size: static number of rows for rotations
+/// * max_iters: number of iterations per eigen vector recoups half on success
+/// * tolerance: error tolerance which is used as a bound for non relative error
+/// * absolute: absolute bound on error minimum should be less than tolerance
+pub fn francis_qr_sym(
+    h: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    range: usize,
+    size: usize,
+    stride: usize,
+    max_iters: usize,
+    tolerance: f32,
+    absolute: f32,
+) {
+    primitives::hessenberg(h, p, w, size, range, stride);
+    symmetric::decomp_sym(h, range, size, stride, max_iters, tolerance, absolute);
+}
+/// francis_qr_complex
+///
+/// * h: householder
+/// * p: projection vector
+/// * w: workspace for a givens rotation
+/// * range: number of rows in active window
+/// * size: static number of rows for rotations
+/// * max_iters: number of iterations per eigen vector recoups half on success
+/// * tolerance: error tolerance which is used as a bound for non relative error
+pub fn francis_qr_cpx(
+    h: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    range: usize,
+    size: usize,
+    stride: usize,
+    max_iters: usize,
+    tolerance: f32,
+) {
+    primitives::hessenberg(h, p, w, size, range, stride);
+    complex::decomp_cpx(h, w, range, size, stride, max_iters, tolerance);
+}
+
+mod test_francis_interface {
+    use super::*;
+
+    use crate::decomposition::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
+    use crate::equality::approximate::approx_scalar_eq;
+    use crate::random::generation::{generate_approx_symmetric_vector, generate_random_vector};
+    fn trace(data: &[f32], n: usize, stride: usize) -> f32 {
+        (0..n).map(|i| data[i * stride + i]).sum()
+    }
+    fn check_francis_qr_sym() -> (bool, bool) {
+        let c = 6;
+        let stride = c;
+        let mut h = generate_approx_symmetric_vector(c);
+        let mut p = vec![0f32; c];
+        let mut w = vec![0f32; c];
+
+        let original_trace = trace(&h, c, stride);
+
+        francis_qr_sym(
+            &mut h,
+            &mut p,
+            &mut w,
+            c,
+            c,
+            stride,
+            MAX_ITERS,
+            TOLERANCE,
+            ABSOLUTE_CAP,
+        );
+
+        let final_trace = trace(&h, c, stride);
+        let trace_ok = approx_scalar_eq(original_trace, final_trace);
+        (true, trace_ok)
+    }
+    fn check_francis_qr_cpx() -> (bool, bool) {
+        let c = 6;
+        let stride = c;
+        let mut h = generate_random_vector(c * c);
+        let mut p = vec![0f32; c];
+        let mut w = vec![0f32; c];
+
+        let original_trace = trace(&h, c, stride);
+
+        francis_qr_cpx(&mut h, &mut p, &mut w, c, c, stride, MAX_ITERS, TOLERANCE);
+
+        let final_trace = trace(&h, c, stride);
+        let trace_ok = approx_scalar_eq(original_trace, final_trace);
+
+        (true, trace_ok)
+    }
+    #[test]
+    fn test_francis_qr_sym() {
+        let trials = 10_000;
+        let mut trace_failures = 0;
+        for _ in 0..trials {
+            let (_, trace_ok) = check_francis_qr_sym();
+            if !trace_ok {
+                trace_failures += 1;
+            }
+        }
+        println!("francis_qr_sym: {trace_failures} trace mismatches / {trials}");
+        assert!(
+            trace_failures < 10,
+            "too many trace mismatches: {trace_failures}"
+        );
+    }
+    #[test]
+    fn test_francis_qr_cpx() {
+        let trials = 10_000;
+        let mut trace_failures = 0;
+        for _ in 0..trials {
+            let (_, trace_ok) = check_francis_qr_cpx();
+            if !trace_ok {
+                trace_failures += 1;
+            }
+        }
+        println!("francis_qr_cpx: {trace_failures} trace mismatches / {trials}");
+        assert!(
+            trace_failures < 10,
+            "too many trace mismatches: {trace_failures}"
+        );
+    }
+}

--- a/spindalis/src/reduction/matrix/francis/mod.rs
+++ b/spindalis/src/reduction/matrix/francis/mod.rs
@@ -1,6 +1,6 @@
 pub mod complex;
-pub mod givens;
 pub mod constants;
+pub mod givens;
 pub mod interface;
 pub mod primitives;
 pub mod symmetric;

--- a/spindalis/src/reduction/matrix/francis/mod.rs
+++ b/spindalis/src/reduction/matrix/francis/mod.rs
@@ -1,0 +1,7 @@
+pub mod complex;
+pub mod givens;
+pub mod constants;
+pub mod interface;
+pub mod primitives;
+pub mod symmetric;
+mod verify; // for testing and reconstruction don't expose

--- a/spindalis/src/reduction/matrix/francis/primitives.rs
+++ b/spindalis/src/reduction/matrix/francis/primitives.rs
@@ -1,0 +1,276 @@
+use crate::decomposition::francis::constants::{EPSILON, MAX_ITERS};
+/// params
+/// takes in data forom a matrix slice
+/// zeros the incoming data and creates the householder vec
+///
+/// if the vector is less than the tolerance the workspace vec
+/// will return nonsense
+///
+/// * v: matrix slice data
+/// * w: sized workspace vector
+pub fn params(v: &mut [f32], w: &mut [f32]) -> f32 {
+    debug_assert_eq!(v.len(), w.len());
+    let mut max_element = 0f32;
+    for val in v.iter() {
+        let v = val.abs();
+        if v > max_element {
+            max_element = v
+        };
+    }
+    if max_element.abs() < EPSILON {
+        w[0] = 1f32;
+        return 0f32;
+    }
+    let mut magnitude_squared = 0f32;
+    let inv_max_element = 1f32 / max_element;
+    for (val, gbg) in v.iter_mut().zip(w.iter_mut()) {
+        *val *= inv_max_element;
+        magnitude_squared += *val * *val;
+        *gbg = *val;
+        *val = 0f32;
+    }
+    let g = w[0].signum() * magnitude_squared.sqrt();
+    let scale = w[0] + g;
+    let inv_scale = 1f32 / scale;
+    for val in w[1..].iter_mut() {
+        *val *= inv_scale;
+    }
+    v[0] = -g * max_element;
+    w[0] = 1f32;
+    scale / g
+}
+/// lapply_householder
+///
+/// applies the transformation directly starting here to apply
+/// to columns 1..cols, simply index into the data and then
+/// stride = cols
+/// cols = cols - 1;
+///
+/// * h: matrix linear data slice
+/// * p: projection slice
+/// * w: workspace slice
+/// * rows: number of rows
+/// * cols: number of cols
+/// * stride: stride of the data
+pub fn lapply_householder(
+    h: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    tau: f32,
+    rows: usize,
+    cols: usize,
+    stride: usize,
+) {
+    debug_assert!(cols <= w.len());
+    debug_assert_eq!(rows, p.len());
+    // (I - tuu')A;
+    // A -= t*uu'A;
+    // w := u'A;
+    // R -= t*uw';
+    let mut roffset = 0;
+    for j in 0..cols {
+        // let scalar = p[0];
+        // scalar implicitly 1
+        w[j] = h[j];
+    }
+    for i in 1..rows {
+        roffset += stride;
+        let scalar = p[i];
+        for j in 0..cols {
+            w[j] += scalar * h[roffset + j];
+        }
+    }
+    for j in 0..cols {
+        w[j] *= tau;
+        h[j] -= w[j];
+    }
+    roffset = 0;
+    for i in 1..rows {
+        roffset += stride;
+        for j in 0..cols {
+            h[roffset + j] -= p[i] * w[j];
+        }
+    }
+}
+/// rapply_householder
+///
+/// applies the transformation directly starting here to apply
+/// to columns 1..cols, simply index into the data and then
+/// stride = cols
+/// cols = cols - 1;
+///
+/// * h: hessenberg matrix data
+/// * p: projection vector
+/// * w: workspace vector
+/// * rows: number of rows
+/// * cols: number of cols
+/// * stride: stride of the data
+pub fn rapply_householder(
+    h: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    tau: f32,
+    rows: usize,
+    cols: usize,
+    stride: usize,
+) {
+    debug_assert!(rows <= w.len());
+    debug_assert_eq!(cols, p.len());
+    // A(I - tuu');
+    // A - t*Auu';
+    // w := Au;
+    // R -= t*wu;
+    let mut roffset = 0;
+    for i in 0..rows {
+        w[i] = h[roffset];
+        for k in 1..cols {
+            w[i] += h[roffset + k] * p[k];
+        }
+        w[i] *= tau;
+        roffset += stride;
+    }
+    roffset = 0;
+    for i in 0..rows {
+        h[roffset] -= w[i];
+        for j in 1..cols {
+            h[roffset + j] -= w[i] * p[j];
+        }
+        roffset += stride;
+    }
+}
+/// hessenberg
+/// * h: matrix to create the hessenberg
+/// * p: projection vector
+/// * w: workspace vector
+/// * rows: number of rows
+/// * cols: number of cols
+/// * stride: stride of the data
+pub fn hessenberg(
+    h: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    rows: usize,
+    cols: usize,
+    stride: usize,
+) {
+    // stores tau
+    let mut offset = 0;
+    let mut active_range = rows;
+    let mut split_range = cols;
+    for o in 1..rows {
+        active_range -= 1;
+        split_range -= 1;
+        let (slice, t) = h.split_at_mut(offset + stride);
+        let slice = &mut slice[offset + o..offset + cols];
+        let proj = &mut p[..split_range];
+        let tau = params(slice, proj);
+        offset += stride;
+        if tau == 0f32 {
+            continue;
+        }
+        rapply_householder(&mut t[o..], proj, w, tau, rows - o, split_range, stride);
+        lapply_householder(&mut h[offset..], proj, w, tau, active_range, cols, stride);
+    }
+}
+pub fn deflate(
+    amount: usize,
+    stride: usize,
+    range: &mut usize,
+    e1: &mut usize,
+    e2: &mut usize,
+    tl: &mut usize,
+    bl: &mut usize,
+    // stall: &mut usize,
+    curriter: &mut usize,
+) {
+    let shift = amount * stride + amount;
+    *range -= amount;
+    *e1 = e1.saturating_sub(shift);
+    *e2 = e2.saturating_sub(shift);
+    *tl = tl.saturating_sub(shift);
+    *bl = bl.saturating_sub(shift);
+    // *stall = 0;
+    *curriter = curriter.saturating_sub(MAX_ITERS >> 1);
+}
+pub fn complex_eig_pair(h: &mut [f32], tl: usize, bl: usize) -> bool {
+    let d = (h[tl] - h[bl + 1]) / 2f32;
+    d * d + h[tl + 1] * h[bl] < EPSILON
+}
+/// double_shift
+///   - standard shift for francis iteration
+///
+/// * h: hessenberg linearized matrix
+/// * p: projection slice
+/// * w: workspace slice
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+pub fn double_shift(
+    h: &mut [f32],
+    w: &mut [f32],
+    stride: usize,
+    _range: usize,
+    tl: usize,
+    bl: usize,
+) {
+    // u1 = a + bi;
+    // u2 = a - bi;
+    // M = H^2 - H(u1 + u2) +Iu1 *u2;
+    // M = H^2 - H *trace +I * det;
+    let (m00, m01) = (h[tl], h[tl + 1]);
+    let (m10, m11) = (h[bl], h[bl + 1]);
+
+    let (h00, h01) = (h[0], h[1]);
+    let (h10, h11) = (h[stride], h[stride + 1]);
+    let h12 = h[stride + 2];
+
+    let trace = m00 + m11;
+    let deter = m00 * m11 - m01 * m10;
+
+    w[0] = h00 * h00 + h01 * h10 - trace * h00 + deter;
+    w[1] = h01 * (h00 + h11 - trace);
+    w[2] = h01 * h12;
+}
+/// exception_shift
+///   - standard shift for francis iteration
+///
+/// * h: hessenberg linearized matrix
+/// * p: projection slice
+/// * w: workspace slice
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+pub fn exception_shift(
+    h: &mut [f32],
+    w: &mut [f32],
+    stride: usize,
+    _range: usize,
+    tl: usize,
+    bl: usize,
+) {
+    // u1 = a + bi;
+    // u2 = a - bi;
+    // M = H^2 - H(u1 + u2) +Iu1 *u2;
+    // M = H^2 - H *trace + I * det;
+    let (_m00, m01) = (h[tl], h[tl + 1]);
+    let (_m10, _m11) = (h[bl], h[bl + 1]);
+
+    let (h00, h01) = (h[0], h[1]);
+    let (h10, h11) = (h[stride], h[stride + 1]);
+    let h12 = h[stride + 2];
+
+    let s = m01.abs() + h01.abs();
+    let trace = 2.0 * s;
+    let deter = s * s;
+
+    w[0] = h00 * h00 + h01 * h10 - trace * h00 + deter;
+    w[1] = h01 * (h00 + h11 - trace);
+    w[2] = h01 * h12;
+}
+pub fn eigen(m00: f32, m01: f32, m10: f32, m11: f32) -> f32 {
+    let d = (m00 - m11) / 2f32;
+    let discriminate = d * d + m10 * m01;
+    if discriminate >= -EPSILON {
+        m11 + d - d.signum() * discriminate.max(0f32).sqrt()
+    } else {
+        m11 + d
+    }
+}

--- a/spindalis/src/reduction/matrix/francis/primitives.rs
+++ b/spindalis/src/reduction/matrix/francis/primitives.rs
@@ -1,4 +1,4 @@
-use crate::decomposition::francis::constants::{EPSILON, MAX_ITERS};
+use crate::reduction::matrix::francis::constants::{EPSILON, MAX_ITERS};
 /// params
 /// takes in data forom a matrix slice
 /// zeros the incoming data and creates the householder vec
@@ -8,9 +8,9 @@ use crate::decomposition::francis::constants::{EPSILON, MAX_ITERS};
 ///
 /// * v: matrix slice data
 /// * w: sized workspace vector
-pub fn params(v: &mut [f32], w: &mut [f32]) -> f32 {
+pub fn params(v: &mut [f64], w: &mut [f64]) -> f64 {
     debug_assert_eq!(v.len(), w.len());
-    let mut max_element = 0f32;
+    let mut max_element = 0f64;
     for val in v.iter() {
         let v = val.abs();
         if v > max_element {
@@ -18,25 +18,25 @@ pub fn params(v: &mut [f32], w: &mut [f32]) -> f32 {
         };
     }
     if max_element.abs() < EPSILON {
-        w[0] = 1f32;
-        return 0f32;
+        w[0] = 1f64;
+        return 0f64;
     }
-    let mut magnitude_squared = 0f32;
-    let inv_max_element = 1f32 / max_element;
+    let mut magnitude_squared = 0f64;
+    let inv_max_element = 1f64 / max_element;
     for (val, gbg) in v.iter_mut().zip(w.iter_mut()) {
         *val *= inv_max_element;
         magnitude_squared += *val * *val;
         *gbg = *val;
-        *val = 0f32;
+        *val = 0f64;
     }
     let g = w[0].signum() * magnitude_squared.sqrt();
     let scale = w[0] + g;
-    let inv_scale = 1f32 / scale;
+    let inv_scale = 1f64 / scale;
     for val in w[1..].iter_mut() {
         *val *= inv_scale;
     }
     v[0] = -g * max_element;
-    w[0] = 1f32;
+    w[0] = 1f64;
     scale / g
 }
 /// lapply_householder
@@ -53,10 +53,10 @@ pub fn params(v: &mut [f32], w: &mut [f32]) -> f32 {
 /// * cols: number of cols
 /// * stride: stride of the data
 pub fn lapply_householder(
-    h: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
-    tau: f32,
+    h: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
+    tau: f64,
     rows: usize,
     cols: usize,
     stride: usize,
@@ -106,10 +106,10 @@ pub fn lapply_householder(
 /// * cols: number of cols
 /// * stride: stride of the data
 pub fn rapply_householder(
-    h: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
-    tau: f32,
+    h: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
+    tau: f64,
     rows: usize,
     cols: usize,
     stride: usize,
@@ -146,9 +146,9 @@ pub fn rapply_householder(
 /// * cols: number of cols
 /// * stride: stride of the data
 pub fn hessenberg(
-    h: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
     rows: usize,
     cols: usize,
     stride: usize,
@@ -165,7 +165,7 @@ pub fn hessenberg(
         let proj = &mut p[..split_range];
         let tau = params(slice, proj);
         offset += stride;
-        if tau == 0f32 {
+        if tau == 0f64 {
             continue;
         }
         rapply_householder(&mut t[o..], proj, w, tau, rows - o, split_range, stride);
@@ -192,8 +192,8 @@ pub fn deflate(
     // *stall = 0;
     *curriter = curriter.saturating_sub(MAX_ITERS >> 1);
 }
-pub fn complex_eig_pair(h: &mut [f32], tl: usize, bl: usize) -> bool {
-    let d = (h[tl] - h[bl + 1]) / 2f32;
+pub fn complex_eig_pair(h: &mut [f64], tl: usize, bl: usize) -> bool {
+    let d = (h[tl] - h[bl + 1]) / 2f64;
     d * d + h[tl + 1] * h[bl] < EPSILON
 }
 /// double_shift
@@ -205,8 +205,8 @@ pub fn complex_eig_pair(h: &mut [f32], tl: usize, bl: usize) -> bool {
 /// * range: number of rows in active window
 /// * stride: stride of the data format
 pub fn double_shift(
-    h: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    w: &mut [f64],
     stride: usize,
     _range: usize,
     tl: usize,
@@ -239,8 +239,8 @@ pub fn double_shift(
 /// * range: number of rows in active window
 /// * stride: stride of the data format
 pub fn exception_shift(
-    h: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    w: &mut [f64],
     stride: usize,
     _range: usize,
     tl: usize,
@@ -265,11 +265,11 @@ pub fn exception_shift(
     w[1] = h01 * (h00 + h11 - trace);
     w[2] = h01 * h12;
 }
-pub fn eigen(m00: f32, m01: f32, m10: f32, m11: f32) -> f32 {
-    let d = (m00 - m11) / 2f32;
+pub fn eigen(m00: f64, m01: f64, m10: f64, m11: f64) -> f64 {
+    let d = (m00 - m11) / 2f64;
     let discriminate = d * d + m10 * m01;
     if discriminate >= -EPSILON {
-        m11 + d - d.signum() * discriminate.max(0f32).sqrt()
+        m11 + d - d.signum() * discriminate.max(0f64).sqrt()
     } else {
         m11 + d
     }

--- a/spindalis/src/reduction/matrix/francis/symmetric.rs
+++ b/spindalis/src/reduction/matrix/francis/symmetric.rs
@@ -1,19 +1,19 @@
-use crate::decomposition::sgivens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+use crate::reduction::matrix::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
 #[rustfmt::skip]
-use crate::decomposition::francis::primitives::{
+use crate::reduction::matrix::francis::primitives::{
     deflate,
     eigen,
 };
 
 #[rustfmt::skip]
 pub fn decomp_sym(
-    h: &mut [f32],
+    h: &mut [f64],
     mut range: usize,
     size: usize,
     stride: usize,
     max_iters:usize,
-    tolerance: f32,
-    absolute: f32,
+    tolerance: f64,
+    absolute: f64,
 ) {
     let s = range * stride;
     // error 1 supra-diagonal above the first real eigen
@@ -62,7 +62,7 @@ pub fn decomp_sym(
 /// * tl: top left of the window for the eigens
 /// * bl: bottom left of the window for the eigens
 pub fn francis_iteration_sym(
-    h: &mut [f32],
+    h: &mut [f64],
     size: usize,
     range: usize,
     stride: usize,

--- a/spindalis/src/reduction/matrix/francis/symmetric.rs
+++ b/spindalis/src/reduction/matrix/francis/symmetric.rs
@@ -1,4 +1,6 @@
-use crate::reduction::matrix::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+use crate::reduction::matrix::francis::givens::{
+    apply_g_left, apply_gt_right, implicit_givens_rotation,
+};
 #[rustfmt::skip]
 use crate::reduction::matrix::francis::primitives::{
     deflate,

--- a/spindalis/src/reduction/matrix/francis/symmetric.rs
+++ b/spindalis/src/reduction/matrix/francis/symmetric.rs
@@ -1,0 +1,84 @@
+use crate::decomposition::sgivens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+#[rustfmt::skip]
+use crate::decomposition::francis::primitives::{
+    deflate,
+    eigen,
+};
+
+#[rustfmt::skip]
+pub fn decomp_sym(
+    h: &mut [f32],
+    mut range: usize,
+    size: usize,
+    stride: usize,
+    max_iters:usize,
+    tolerance: f32,
+    absolute: f32,
+) {
+    let s = range * stride;
+    // error 1 supra-diagonal above the first real eigen
+    // error 2 supra-diagonal above the second complex real eigen
+    let mut e1 = s.saturating_sub(stride + 1);
+    let mut e2 = s.saturating_sub(stride + stride + 2);
+    let mut tl = s.saturating_sub(stride + 2);
+    let mut bl = s.saturating_sub(2);
+    let mut curriter = 0;
+    while range > 1 && curriter < max_iters {
+        let scale = h[tl].abs() + h[bl+1].abs();
+        curriter += 1;
+        if h[e1].abs() < (scale * tolerance).min(absolute) {
+            deflate(
+                1,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+        } else if h[e2].abs() < tolerance && curriter == max_iters {
+            deflate(
+                2,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+        } else {
+            francis_iteration_sym(h, size, range, stride, tl, bl);
+        }
+    }
+}
+/// francis_iteration_sym
+///
+/// * h: hessenberg linearized matrix
+/// * size: static number of rows for rotations
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+/// * tl: top left of the window for the eigens
+/// * bl: bottom left of the window for the eigens
+pub fn francis_iteration_sym(
+    h: &mut [f32],
+    size: usize,
+    range: usize,
+    stride: usize,
+    tl: usize,
+    bl: usize,
+) {
+    let eig = eigen(h[tl], h[tl + 1], h[bl], h[bl + 1]);
+    let (_, cosine, sine) = implicit_givens_rotation(h[0] - eig, h[1]);
+    apply_gt_right(h, 0, 1, stride, size, cosine, sine);
+    apply_g_left(h, 0, 1, stride, size, cosine, sine);
+    for o in 0..range.saturating_sub(2) {
+        let row = o * stride;
+        let s1 = o + 1;
+        let s2 = o + 2;
+        let (_, cosine, sine) = implicit_givens_rotation(h[row + s1], h[row + s2]);
+        apply_gt_right(&mut h[row..], s1, s2, stride, range - o, cosine, sine);
+        apply_g_left(h, s1, s2, stride, range, cosine, sine);
+    }
+}

--- a/spindalis/src/reduction/matrix/francis/verify.rs
+++ b/spindalis/src/reduction/matrix/francis/verify.rs
@@ -1,5 +1,7 @@
 use crate::reduction::matrix::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
-use crate::reduction::matrix::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+use crate::reduction::matrix::francis::givens::{
+    apply_g_left, apply_gt_right, implicit_givens_rotation,
+};
 #[rustfmt::skip]
 use crate::reduction::matrix::francis::primitives::{
     params,
@@ -374,7 +376,12 @@ mod test_hessenberg_reconstructions {
                 "dim={dim}: R' R not orthogonal, got {rtr}"
             );
             // R' H R ~= original
-            let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
+            let reconstruct = rotation
+                .transpose()
+                .dot(&kernel)
+                .unwrap()
+                .dot(&rotation)
+                .unwrap();
             assert!(
                 approx_vector_eq(&flat(&reconstruct), &flat(&original)),
                 "dim={dim}: reconstruction mismatch, got {reconstruct} expected {original}"
@@ -419,7 +426,12 @@ mod test_hessenberg_reconstructions {
             }
 
             // R' H R ~= original
-            let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
+            let reconstruct = rotation
+                .transpose()
+                .dot(&kernel)
+                .unwrap()
+                .dot(&rotation)
+                .unwrap();
             assert!(
                 approx_vector_eq(&flat(&reconstruct), &flat(&original)),
                 "dim={dim}: symmetric reconstruction mismatch"
@@ -448,7 +460,12 @@ mod test_hessenberg_reconstructions {
 
         let rrt = rotation.dot(&rotation.transpose()).unwrap();
         let rtr = rotation.transpose().dot(&rotation).unwrap();
-        let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
+        let reconstruct = rotation
+            .transpose()
+            .dot(&kernel)
+            .unwrap()
+            .dot(&rotation)
+            .unwrap();
 
         let ortho_ok = approx_vector_eq(&flat(&rrt), &flat(&identity))
             && approx_vector_eq(&flat(&rtr), &flat(&identity));
@@ -496,7 +513,12 @@ mod test_hessenberg_reconstructions {
 
         let rrt = rotation.dot(&rotation.transpose()).unwrap();
         let rtr = rotation.transpose().dot(&rotation).unwrap();
-        let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
+        let reconstruct = rotation
+            .transpose()
+            .dot(&kernel)
+            .unwrap()
+            .dot(&rotation)
+            .unwrap();
 
         let ortho_ok = approx_vector_eq(&flat(&rrt), &flat(&identity))
             && approx_vector_eq(&flat(&rtr), &flat(&identity));

--- a/spindalis/src/reduction/matrix/francis/verify.rs
+++ b/spindalis/src/reduction/matrix/francis/verify.rs
@@ -1,0 +1,490 @@
+use crate::decomposition::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
+use crate::decomposition::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+#[rustfmt::skip]
+use crate::decomposition::francis::primitives::{
+    params,
+    deflate,
+    eigen,
+    double_shift,
+    exception_shift,
+    complex_eig_pair,
+    lapply_householder,
+    rapply_householder,
+};
+
+#[rustfmt::skip]
+pub fn full_decomp_sym(
+    h: &mut [f32],
+    r: &mut [f32],
+    mut range: usize,
+    size: usize,
+    stride: usize
+) -> bool {
+    let s = range * stride;
+    let mut e1 = s.saturating_sub(stride + 1);
+    let mut e2 = s.saturating_sub(stride + stride + 2);
+    let mut tl = s.saturating_sub(stride + 2);
+    let mut bl = s.saturating_sub(2);
+    let mut curriter = 0;
+    let mut error = vec![];
+    while range > 1 && curriter < MAX_ITERS {
+        let scale = h[tl].abs() + h[bl+1].abs();
+        curriter += 1;
+        if h[e1].abs() < (scale * TOLERANCE).min(ABSOLUTE_CAP) {
+            deflate(
+                1,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+            error = vec![];
+        } else if h[e2].abs() < TOLERANCE && curriter == MAX_ITERS {
+            deflate(
+                2,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+            error = vec![];
+        } else {
+            full_francis_iteration_sym(h, r, size, range, stride, tl, bl);
+        }
+        error.push(h[e1]);
+    }
+    range <= 1
+}
+pub fn full_decomp_cpx(
+    h: &mut [f32],
+    r: &mut [f32],
+    w: &mut [f32],
+    mut range: usize,
+    size: usize,
+    stride: usize,
+) -> bool {
+    let s = range * stride;
+    let mut e1 = s.saturating_sub(stride + 1);
+    let mut e2 = s.saturating_sub(stride + stride + 2);
+    let mut tl = s.saturating_sub(stride + 2);
+    let mut bl = s.saturating_sub(2);
+    let mut curriter = 0;
+    let _he1 = h[e1];
+    let _he2 = h[e2];
+    let p = &mut [0f32; 3];
+    let mut stall = 0;
+    while range > 0 && curriter < MAX_ITERS {
+        curriter += 1;
+        if h[e1].abs() < TOLERANCE {
+            stall = 0;
+            deflate(
+                1,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+        } else if h[e2].abs() < TOLERANCE {
+            // if e2 == 0 then we are hitting eigen which should be greater than tolerance
+            deflate(
+                2,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+            stall = 0;
+        } else if range == 2 && complex_eig_pair(h, tl, bl) {
+            deflate(
+                2,
+                stride,
+                &mut range,
+                &mut e1,
+                &mut e2,
+                &mut tl,
+                &mut bl,
+                &mut curriter,
+            );
+            stall = 0;
+        } else {
+            if range == 2 {
+                full_francis_iteration_cpx_2x2(h, r, size, stride, tl, bl);
+            // } else if stall > 0 && (stall + 4) % 10 == 0 {
+            } else if (stall + 8) % 12 == 0 {
+                // } else if (stall + 4) % 10 == 0 {
+                // } else if stall == 6 {
+                exception_shift(h, w, stride, range, tl, bl);
+                full_francis_iteration_cpx(h, r, p, w, size, range, stride, tl, bl);
+            } else {
+                double_shift(h, w, stride, range, tl, bl);
+                full_francis_iteration_cpx(h, r, p, w, size, range, stride, tl, bl);
+            }
+            stall += 1;
+        }
+    }
+    range <= 1
+}
+/// francis_iteration_cpx
+///
+/// * h: hessenberg linearized matrix
+/// * r: rotaiton linearized matrix
+/// * p: projection slice
+/// * w: workspace slice
+/// * size: static number of rows for rotations
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+pub fn full_francis_iteration_cpx(
+    h: &mut [f32],
+    r: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    size: usize,
+    range: usize,
+    stride: usize,
+    _tl: usize,
+    _bl: usize,
+) {
+    let bound = range.min(3);
+    let p = &mut p[..bound];
+    let tau = params(&mut w[..bound], p);
+    if tau != 0f32 {
+        rapply_householder(h, p, w, tau, size, bound, stride);
+        lapply_householder(h, p, w, tau, bound, range, stride);
+        // ----------------- tracking the rotation matrix
+        lapply_householder(r, p, w, tau, bound, size, stride);
+    }
+    let mut offset = 0;
+    for o in 1..range.saturating_sub(1) {
+        let bound = bound.min(stride - o);
+        let (slice, t) = h.split_at_mut(offset + stride);
+        let slice = &mut slice[offset + o..offset + o + bound];
+        let proj = &mut p[..bound];
+        let tau = params(slice, proj);
+        offset += stride;
+        if tau == 0f32 {
+            continue;
+        }
+        rapply_householder(&mut t[o..], proj, w, tau, size - o, bound, stride);
+        lapply_householder(&mut h[offset..], proj, w, tau, bound, range, stride);
+        // ----------------- tracking the rotation matrix
+        lapply_householder(&mut r[offset..], proj, w, tau, bound, size, stride);
+    }
+}
+pub fn full_francis_iteration_cpx_2x2(
+    h: &mut [f32],
+    r: &mut [f32],
+    size: usize,
+    stride: usize,
+    tl: usize,
+    bl: usize,
+) {
+    let eig = eigen(h[tl], h[tl + 1], h[bl], h[bl + 1]);
+    let (_, cosine, sine) = implicit_givens_rotation(h[0] - eig, h[1]);
+    apply_gt_right(h, 0, 1, stride, size, cosine, sine);
+    apply_g_left(h, 0, 1, stride, 2, cosine, sine);
+    apply_g_left(r, 0, 1, stride, size, cosine, sine);
+}
+/// full_francis_iteration_sym
+///
+/// * h: hessenberg linearized matrix
+/// * r: rotation accumulated linearized matrix
+/// * size: static number of rows for rotations
+/// * range: number of rows in active window
+/// * stride: stride of the data format
+/// * tl: top left of the window for the eigens
+/// * bl: bottom left of the window for the eigens
+pub fn full_francis_iteration_sym(
+    h: &mut [f32],
+    r: &mut [f32],
+    size: usize,
+    range: usize,
+    stride: usize,
+    tl: usize,
+    bl: usize,
+) {
+    let eig = eigen(h[tl], h[tl + 1], h[bl], h[bl + 1]);
+    let (_, cosine, sine) = implicit_givens_rotation(h[0] - eig, h[1]);
+    apply_gt_right(h, 0, 1, stride, size, cosine, sine);
+    apply_g_left(h, 0, 1, stride, size, cosine, sine);
+    apply_g_left(r, 0, 1, stride, size, cosine, sine);
+    for o in 0..range.saturating_sub(2) {
+        let row = o * stride;
+        let s1 = o + 1;
+        let s2 = o + 2;
+        let (_, cosine, sine) = implicit_givens_rotation(h[row + s1], h[row + s2]);
+        apply_gt_right(&mut h[row..], s1, s2, stride, range - o, cosine, sine);
+        apply_g_left(h, s1, s2, stride, range, cosine, sine);
+        apply_g_left(r, s1, s2, stride, size, cosine, sine);
+    }
+}
+/// full_hessenberg
+/// * h: matrix to create the hessenberg
+/// * r: rotation matrix should be identity on coldstart
+/// * p: projection vector
+/// * w: workspace vector
+/// * rows: number of rows
+/// * cols: number of cols
+/// * stride: stride of the data
+pub fn full_hessenberg(
+    h: &mut [f32],
+    r: &mut [f32],
+    p: &mut [f32],
+    w: &mut [f32],
+    rows: usize,
+    cols: usize,
+    stride: usize,
+) {
+    // stores tau
+    let mut offset = 0;
+    let mut active_range = rows;
+    let mut split_range = cols;
+    for o in 1..rows {
+        active_range -= 1;
+        split_range -= 1;
+        let (slice, t) = h.split_at_mut(offset + stride);
+        let slice = &mut slice[offset + o..offset + cols];
+        let proj = &mut p[..split_range];
+        let tau = params(slice, proj);
+        offset += stride;
+        if tau == 0f32 {
+            continue;
+        }
+        rapply_householder(&mut t[o..], proj, w, tau, rows - o, split_range, stride);
+        lapply_householder(&mut h[offset..], proj, w, tau, active_range, cols, stride);
+        lapply_householder(&mut r[offset..], proj, w, tau, active_range, cols, stride);
+    }
+}
+mod test_hessenberg_reconstructions {
+    use super::*;
+
+    use crate::algebra::ndmethods::matrix_mult;
+    use crate::equality::approximate::approx_vector_eq;
+    use crate::random::generation::{
+        generate_approx_symmetric_vector, generate_identity_vector, generate_random_vector,
+    };
+    use crate::structure::ndarray::NdArray;
+
+    #[test]
+    fn test_hessenberg_reconstruct_general() {
+        for dim in [1, 2, 4, 7] {
+            let (rows, cols) = (dim, dim);
+            let stride = dim;
+            let mut h = generate_random_vector(rows * cols);
+            let mut r = generate_identity_vector(rows, cols);
+            let mut p = vec![0f32; cols];
+            let mut w = vec![0f32; rows];
+            let original = NdArray {
+                dims: vec![rows, cols],
+                data: h.clone(),
+            };
+            full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
+            let kernel = NdArray {
+                dims: vec![rows, cols],
+                data: h.clone(),
+            };
+            let rotation = NdArray {
+                dims: vec![rows, cols],
+                data: r.clone(),
+            };
+            // R R' ~= I
+            let rrt = matrix_mult(&rotation, &rotation.transpose());
+            let identity = generate_identity_vector(rows, cols);
+            assert!(
+                approx_vector_eq(&rrt.data, &identity),
+                "dim={dim}: R R' not orthogonal, got {:?}",
+                rrt.data
+            );
+            // R' R ~= I
+            let rtr = matrix_mult(&rotation.transpose(), &rotation);
+            assert!(
+                approx_vector_eq(&rtr.data, &identity),
+                "dim={dim}: R' R not orthogonal, got {:?}",
+                rtr.data
+            );
+            // R' H R ~= original
+            let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+            assert!(
+                approx_vector_eq(&reconstruct.data, &original.data),
+                "dim={dim}: reconstruction mismatch, got {:?} expected {:?}",
+                reconstruct.data,
+                original.data
+            );
+        }
+    }
+    #[test]
+    fn test_hessenberg_reconstruct_symmetric() {
+        for dim in [1, 2, 4, 7] {
+            let (rows, cols) = (dim, dim);
+            let stride = dim;
+            let mut h = generate_approx_symmetric_vector(dim);
+            let mut r = generate_identity_vector(rows, cols);
+            let mut p = vec![0f32; cols];
+            let mut w = vec![0f32; rows];
+            let original = NdArray {
+                dims: vec![rows, cols],
+                data: h.clone(),
+            };
+            full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
+            let kernel = NdArray {
+                dims: vec![rows, cols],
+                data: h.clone(),
+            };
+            let rotation = NdArray {
+                dims: vec![rows, cols],
+                data: r.clone(),
+            };
+            let identity = generate_identity_vector(rows, cols);
+            let rrt = matrix_mult(&rotation, &rotation.transpose());
+            assert!(
+                approx_vector_eq(&rrt.data, &identity),
+                "dim={dim}: R R' not orthogonal"
+            );
+            // symmetric-specific: hessenberg of a symmetric matrix should be
+            // tridiagonal, i.e. zero below the first subdiagonal
+            for i in 0..rows {
+                for j in 0..cols {
+                    if i > j + 1 {
+                        assert!(
+                            h[i * stride + j].abs() < 1e-2,
+                            "dim={dim}: expected tridiagonal, got h[{i}][{j}]={}",
+                            h[i * stride + j]
+                        );
+                    }
+                }
+            }
+            // R' H R ~= original
+            let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+            assert!(
+                approx_vector_eq(&reconstruct.data, &original.data),
+                "dim={dim}: symmetric reconstruction mismatch"
+            );
+        }
+    }
+    fn check_decomp_sym_reconstruct() -> (bool, bool) {
+        // returns (converged, reconstruction_ok)
+        let c = 6;
+        let (rows, cols) = (c, c);
+        let stride = c;
+
+        let mut h = generate_approx_symmetric_vector(rows);
+        let mut r = generate_identity_vector(rows, cols);
+        let mut p = vec![0f32; cols];
+        let mut w = vec![0f32; rows];
+
+        let original = NdArray {
+            dims: vec![rows, cols],
+            data: h.clone(),
+        };
+
+        full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
+        let converged = full_decomp_sym(&mut h, &mut r, c, c, c);
+
+        let kernel = NdArray {
+            dims: vec![rows, cols],
+            data: h.clone(),
+        };
+        let rotation = NdArray {
+            dims: vec![rows, cols],
+            data: r.clone(),
+        };
+
+        let identity = generate_identity_vector(rows, cols);
+        let rrt = matrix_mult(&rotation, &rotation.transpose());
+        let rtr = matrix_mult(&rotation.transpose(), &rotation);
+        let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+
+        let ortho_ok =
+            approx_vector_eq(&rrt.data, &identity) && approx_vector_eq(&rtr.data, &identity);
+        let recon_ok = approx_vector_eq(&reconstruct.data, &original.data);
+
+        (converged, ortho_ok && recon_ok)
+    }
+    #[rustfmt::skip]
+    #[test]
+    fn test_symmetric_reconstruct() {
+        let trials = 10_000;
+        let mut convergence_failures = 0;
+        let mut reconstruction_failures = 0;
+
+        for _ in 0..trials {
+            let (converged, reconstructed) = check_decomp_sym_reconstruct();
+            if !converged { convergence_failures += 1; }
+            if !reconstructed { reconstruction_failures += 1; }
+        }
+
+        println!("sym: {convergence_failures} convergence failures, {reconstruction_failures} reconstruction failures / {trials}");
+        assert!(convergence_failures < 10, "too many convergence failures: {convergence_failures}");
+        assert!(reconstruction_failures < 10, "too many reconstruction failures: {reconstruction_failures}");
+    }
+    fn check_decomp_cpx_reconstruct() -> (bool, bool) {
+        // returns (converged, reconstruction_ok)
+        let c = 6;
+        let (rows, cols) = (c, c);
+        let stride = c;
+
+        let mut h = generate_random_vector(rows * cols);
+        let mut r = generate_identity_vector(rows, cols);
+        let mut p = vec![0f32; cols];
+        let mut w = vec![0f32; rows];
+
+        let original = NdArray {
+            dims: vec![rows, cols],
+            data: h.clone(),
+        };
+
+        full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
+        let converged = full_decomp_cpx(&mut h, &mut r, &mut w, c, c, c);
+
+        let kernel = NdArray {
+            dims: vec![rows, cols],
+            data: h.clone(),
+        };
+        let rotation = NdArray {
+            dims: vec![rows, cols],
+            data: r.clone(),
+        };
+
+        let identity = generate_identity_vector(rows, cols);
+        let rrt = matrix_mult(&rotation, &rotation.transpose());
+        let rtr = matrix_mult(&rotation.transpose(), &rotation);
+        let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+
+        let ortho_ok =
+            approx_vector_eq(&rrt.data, &identity) && approx_vector_eq(&rtr.data, &identity);
+        let recon_ok = approx_vector_eq(&reconstruct.data, &original.data);
+
+        (converged, ortho_ok && recon_ok)
+    }
+    #[rustfmt::skip]
+    #[test]
+    fn test_complex_reconstruct() {
+        let trials = 10_000;
+        let mut convergence_failures = 0;
+        let mut reconstruction_failures = 0;
+
+        for _ in 0..trials {
+            let (converged, reconstructed) = check_decomp_cpx_reconstruct();
+            if !converged {
+                convergence_failures += 1;
+            }
+            if !reconstructed {
+                reconstruction_failures += 1;
+            }
+        }
+        println!("cpx: {convergence_failures} convergence failures, {reconstruction_failures} reconstruction failures / {trials}");
+        assert!( convergence_failures < 10, "too many convergence failures: {convergence_failures}");
+        assert!( reconstruction_failures < 10, "too many reconstruction failures: {reconstruction_failures}");
+    }
+}

--- a/spindalis/src/reduction/matrix/francis/verify.rs
+++ b/spindalis/src/reduction/matrix/francis/verify.rs
@@ -278,13 +278,17 @@ mod test_hessenberg_reconstructions {
     //  NOTE: This should also be weighted towards the size of the dimensionality
     //  of the decomposition ie the condition number not a flat tolerance level
     const TOLERANCE: f64 = 1e-2;
-    // NOTE for spindalis maintainers: Matrix2D has no public way to get at
-    // `inner` as one flat buffer (only per-row slices via rows()/rows_mut(),
-    // or (row,col) indexing). Every reconstruction check below has to build
-    // fresh Matrix2Ds via from_flat and read them back out via
-    // rows().flatten() to compare — a `from_vec`-style constructor that
-    // takes ownership without the from_flat padding/validation path, or an
-    // `as_slice`/`as_mut_slice` pair, would let this skip the copies.
+    fn approx_vector_eq(a: &[f64], b: &[f64]) -> bool {
+        let n = a.len();
+        let mut error = 0f64;
+        for i in 0..n {
+            if a[i].is_nan() || b[i].is_nan() {
+                return false;
+            }
+            error += (a[i] - b[i]).abs();
+        }
+        error / (n as f64).sqrt() < TOLERANCE
+    }
 
     fn to_matrix(data: &[f64], rows: usize, cols: usize) -> Matrix2D<f64> {
         Matrix2D::from_flat(data.to_vec(), 0.0, rows, cols).unwrap()
@@ -300,7 +304,7 @@ mod test_hessenberg_reconstructions {
         }
         data
     }
-    pub fn generate_identity_vector(m: usize, n: usize) -> Vec<f64> {
+    fn generate_identity_vector(m: usize, n: usize) -> Vec<f64> {
         let mut vector = vec![0f64; m * n];
         let mut idx = 0;
         for _ in 0..m {
@@ -320,7 +324,7 @@ mod test_hessenberg_reconstructions {
     //     data
     // }
     /// Creates some f64 style noise in order to replicate working with matrices
-    pub fn generate_approx_symmetric_vector(n: usize) -> Vec<f64> {
+    fn generate_approx_symmetric_vector(n: usize) -> Vec<f64> {
         let a = generate_random_vector(n * n); // flat, row-major, stride = n
         let mut result = vec![0f64; n * n];
         for i in 0..n {
@@ -334,17 +338,6 @@ mod test_hessenberg_reconstructions {
             }
         }
         result
-    }
-    fn approx_vector_eq(a: &[f64], b: &[f64]) -> bool {
-        let n = a.len();
-        let mut error = 0f64;
-        for i in 0..n {
-            if a[i].is_nan() || b[i].is_nan() {
-                return false;
-            }
-            error += (a[i] - b[i]).abs();
-        }
-        error / (n as f64).sqrt() < TOLERANCE
     }
     #[test]
     fn test_hessenberg_reconstruct_general() {

--- a/spindalis/src/reduction/matrix/francis/verify.rs
+++ b/spindalis/src/reduction/matrix/francis/verify.rs
@@ -1,7 +1,7 @@
-use crate::decomposition::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
-use crate::decomposition::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
+use crate::reduction::matrix::francis::constants::{ABSOLUTE_CAP, MAX_ITERS, TOLERANCE};
+use crate::reduction::matrix::francis::givens::{apply_g_left, apply_gt_right, implicit_givens_rotation};
 #[rustfmt::skip]
-use crate::decomposition::francis::primitives::{
+use crate::reduction::matrix::francis::primitives::{
     params,
     deflate,
     eigen,
@@ -14,8 +14,8 @@ use crate::decomposition::francis::primitives::{
 
 #[rustfmt::skip]
 pub fn full_decomp_sym(
-    h: &mut [f32],
-    r: &mut [f32],
+    h: &mut [f64],
+    r: &mut [f64],
     mut range: usize,
     size: usize,
     stride: usize
@@ -62,9 +62,9 @@ pub fn full_decomp_sym(
     range <= 1
 }
 pub fn full_decomp_cpx(
-    h: &mut [f32],
-    r: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    r: &mut [f64],
+    w: &mut [f64],
     mut range: usize,
     size: usize,
     stride: usize,
@@ -77,7 +77,7 @@ pub fn full_decomp_cpx(
     let mut curriter = 0;
     let _he1 = h[e1];
     let _he2 = h[e2];
-    let p = &mut [0f32; 3];
+    let p = &mut [0f64; 3];
     let mut stall = 0;
     while range > 0 && curriter < MAX_ITERS {
         curriter += 1;
@@ -146,10 +146,10 @@ pub fn full_decomp_cpx(
 /// * range: number of rows in active window
 /// * stride: stride of the data format
 pub fn full_francis_iteration_cpx(
-    h: &mut [f32],
-    r: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    r: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
     size: usize,
     range: usize,
     stride: usize,
@@ -159,7 +159,7 @@ pub fn full_francis_iteration_cpx(
     let bound = range.min(3);
     let p = &mut p[..bound];
     let tau = params(&mut w[..bound], p);
-    if tau != 0f32 {
+    if tau != 0f64 {
         rapply_householder(h, p, w, tau, size, bound, stride);
         lapply_householder(h, p, w, tau, bound, range, stride);
         // ----------------- tracking the rotation matrix
@@ -173,7 +173,7 @@ pub fn full_francis_iteration_cpx(
         let proj = &mut p[..bound];
         let tau = params(slice, proj);
         offset += stride;
-        if tau == 0f32 {
+        if tau == 0f64 {
             continue;
         }
         rapply_householder(&mut t[o..], proj, w, tau, size - o, bound, stride);
@@ -183,8 +183,8 @@ pub fn full_francis_iteration_cpx(
     }
 }
 pub fn full_francis_iteration_cpx_2x2(
-    h: &mut [f32],
-    r: &mut [f32],
+    h: &mut [f64],
+    r: &mut [f64],
     size: usize,
     stride: usize,
     tl: usize,
@@ -206,8 +206,8 @@ pub fn full_francis_iteration_cpx_2x2(
 /// * tl: top left of the window for the eigens
 /// * bl: bottom left of the window for the eigens
 pub fn full_francis_iteration_sym(
-    h: &mut [f32],
-    r: &mut [f32],
+    h: &mut [f64],
+    r: &mut [f64],
     size: usize,
     range: usize,
     stride: usize,
@@ -238,10 +238,10 @@ pub fn full_francis_iteration_sym(
 /// * cols: number of cols
 /// * stride: stride of the data
 pub fn full_hessenberg(
-    h: &mut [f32],
-    r: &mut [f32],
-    p: &mut [f32],
-    w: &mut [f32],
+    h: &mut [f64],
+    r: &mut [f64],
+    p: &mut [f64],
+    w: &mut [f64],
     rows: usize,
     cols: usize,
     stride: usize,
@@ -258,7 +258,7 @@ pub fn full_hessenberg(
         let proj = &mut p[..split_range];
         let tau = params(slice, proj);
         offset += stride;
-        if tau == 0f32 {
+        if tau == 0f64 {
             continue;
         }
         rapply_householder(&mut t[o..], proj, w, tau, rows - o, split_range, stride);
@@ -266,16 +266,84 @@ pub fn full_hessenberg(
         lapply_householder(&mut r[offset..], proj, w, tau, active_range, cols, stride);
     }
 }
+#[cfg(test)]
 mod test_hessenberg_reconstructions {
     use super::*;
+    use rand::prelude::*;
 
-    use crate::algebra::ndmethods::matrix_mult;
-    use crate::equality::approximate::approx_vector_eq;
-    use crate::random::generation::{
-        generate_approx_symmetric_vector, generate_identity_vector, generate_random_vector,
-    };
-    use crate::structure::ndarray::NdArray;
+    use jedvek::Matrix2D;
+    use rand_distr::StandardNormal;
+    //  NOTE: This should also be weighted towards the size of the dimensionality
+    //  of the decomposition ie the condition number not a flat tolerance level
+    const TOLERANCE: f64 = 1e-2;
+    // NOTE for spindalis maintainers: Matrix2D has no public way to get at
+    // `inner` as one flat buffer (only per-row slices via rows()/rows_mut(),
+    // or (row,col) indexing). Every reconstruction check below has to build
+    // fresh Matrix2Ds via from_flat and read them back out via
+    // rows().flatten() to compare — a `from_vec`-style constructor that
+    // takes ownership without the from_flat padding/validation path, or an
+    // `as_slice`/`as_mut_slice` pair, would let this skip the copies.
 
+    fn to_matrix(data: &[f64], rows: usize, cols: usize) -> Matrix2D<f64> {
+        Matrix2D::from_flat(data.to_vec(), 0.0, rows, cols).unwrap()
+    }
+    fn flat(m: &Matrix2D<f64>) -> Vec<f64> {
+        m.rows().flatten().copied().collect()
+    }
+    fn generate_random_vector(n: usize) -> Vec<f64> {
+        let mut rng = rand::rng();
+        let mut data = vec![0f64; n];
+        for i in 0..n {
+            data[i] = rng.sample(StandardNormal);
+        }
+        data
+    }
+    pub fn generate_identity_vector(m: usize, n: usize) -> Vec<f64> {
+        let mut vector = vec![0f64; m * n];
+        let mut idx = 0;
+        for _ in 0..m {
+            vector[idx] = 1f64;
+            idx += 1 + n;
+        }
+        vector
+    }
+    // fn generate_strict_symmetric_vector(n: usize) -> Vec<f64> {
+    //     let mut data = generate_random_vector(n * n);
+    //     for i in 0..n {
+    //         for j in 0..i {
+    //             let val = data[i * n + j];
+    //             data[j * n + i] = val;
+    //         }
+    //     }
+    //     data
+    // }
+    /// Creates some f64 style noise in order to replicate working with matrices
+    pub fn generate_approx_symmetric_vector(n: usize) -> Vec<f64> {
+        let a = generate_random_vector(n * n); // flat, row-major, stride = n
+        let mut result = vec![0f64; n * n];
+        for i in 0..n {
+            for j in 0..n {
+                let mut sum = 0f64;
+                for k in 0..n {
+                    // A[i][k] * A[j][k]  ==  (A * A^T)[i][j]
+                    sum += a[i * n + k] * a[j * n + k];
+                }
+                result[i * n + j] = sum;
+            }
+        }
+        result
+    }
+    fn approx_vector_eq(a: &[f64], b: &[f64]) -> bool {
+        let n = a.len();
+        let mut error = 0f64;
+        for i in 0..n {
+            if a[i].is_nan() || b[i].is_nan() {
+                return false;
+            }
+            error += (a[i] - b[i]).abs();
+        }
+        error / (n as f64).sqrt() < TOLERANCE
+    }
     #[test]
     fn test_hessenberg_reconstruct_general() {
         for dim in [1, 2, 4, 7] {
@@ -283,43 +351,33 @@ mod test_hessenberg_reconstructions {
             let stride = dim;
             let mut h = generate_random_vector(rows * cols);
             let mut r = generate_identity_vector(rows, cols);
-            let mut p = vec![0f32; cols];
-            let mut w = vec![0f32; rows];
-            let original = NdArray {
-                dims: vec![rows, cols],
-                data: h.clone(),
-            };
+            let mut p = vec![0f64; cols];
+            let mut w = vec![0f64; rows];
+            let original = to_matrix(&h, rows, cols);
+
             full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
-            let kernel = NdArray {
-                dims: vec![rows, cols],
-                data: h.clone(),
-            };
-            let rotation = NdArray {
-                dims: vec![rows, cols],
-                data: r.clone(),
-            };
+
+            let kernel = to_matrix(&h, rows, cols);
+            let rotation = to_matrix(&r, rows, cols);
+            let identity = Matrix2D::identity(dim);
+
             // R R' ~= I
-            let rrt = matrix_mult(&rotation, &rotation.transpose());
-            let identity = generate_identity_vector(rows, cols);
+            let rrt = rotation.dot(&rotation.transpose()).unwrap();
             assert!(
-                approx_vector_eq(&rrt.data, &identity),
-                "dim={dim}: R R' not orthogonal, got {:?}",
-                rrt.data
+                approx_vector_eq(&flat(&rrt), &flat(&identity)),
+                "dim={dim}: R R' not orthogonal, got {rrt}"
             );
             // R' R ~= I
-            let rtr = matrix_mult(&rotation.transpose(), &rotation);
+            let rtr = rotation.transpose().dot(&rotation).unwrap();
             assert!(
-                approx_vector_eq(&rtr.data, &identity),
-                "dim={dim}: R' R not orthogonal, got {:?}",
-                rtr.data
+                approx_vector_eq(&flat(&rtr), &flat(&identity)),
+                "dim={dim}: R' R not orthogonal, got {rtr}"
             );
             // R' H R ~= original
-            let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+            let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
             assert!(
-                approx_vector_eq(&reconstruct.data, &original.data),
-                "dim={dim}: reconstruction mismatch, got {:?} expected {:?}",
-                reconstruct.data,
-                original.data
+                approx_vector_eq(&flat(&reconstruct), &flat(&original)),
+                "dim={dim}: reconstruction mismatch, got {reconstruct} expected {original}"
             );
         }
     }
@@ -330,27 +388,22 @@ mod test_hessenberg_reconstructions {
             let stride = dim;
             let mut h = generate_approx_symmetric_vector(dim);
             let mut r = generate_identity_vector(rows, cols);
-            let mut p = vec![0f32; cols];
-            let mut w = vec![0f32; rows];
-            let original = NdArray {
-                dims: vec![rows, cols],
-                data: h.clone(),
-            };
+            let mut p = vec![0f64; cols];
+            let mut w = vec![0f64; rows];
+            let original = to_matrix(&h, rows, cols);
+
             full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
-            let kernel = NdArray {
-                dims: vec![rows, cols],
-                data: h.clone(),
-            };
-            let rotation = NdArray {
-                dims: vec![rows, cols],
-                data: r.clone(),
-            };
-            let identity = generate_identity_vector(rows, cols);
-            let rrt = matrix_mult(&rotation, &rotation.transpose());
+
+            let kernel = to_matrix(&h, rows, cols);
+            let rotation = to_matrix(&r, rows, cols);
+            let identity = Matrix2D::identity(dim);
+
+            let rrt = rotation.dot(&rotation.transpose()).unwrap();
             assert!(
-                approx_vector_eq(&rrt.data, &identity),
+                approx_vector_eq(&flat(&rrt), &flat(&identity)),
                 "dim={dim}: R R' not orthogonal"
             );
+
             // symmetric-specific: hessenberg of a symmetric matrix should be
             // tridiagonal, i.e. zero below the first subdiagonal
             for i in 0..rows {
@@ -364,53 +417,46 @@ mod test_hessenberg_reconstructions {
                     }
                 }
             }
+
             // R' H R ~= original
-            let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+            let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
             assert!(
-                approx_vector_eq(&reconstruct.data, &original.data),
+                approx_vector_eq(&flat(&reconstruct), &flat(&original)),
                 "dim={dim}: symmetric reconstruction mismatch"
             );
         }
     }
+
     fn check_decomp_sym_reconstruct() -> (bool, bool) {
-        // returns (converged, reconstruction_ok)
         let c = 6;
         let (rows, cols) = (c, c);
         let stride = c;
 
         let mut h = generate_approx_symmetric_vector(rows);
         let mut r = generate_identity_vector(rows, cols);
-        let mut p = vec![0f32; cols];
-        let mut w = vec![0f32; rows];
+        let mut p = vec![0f64; cols];
+        let mut w = vec![0f64; rows];
 
-        let original = NdArray {
-            dims: vec![rows, cols],
-            data: h.clone(),
-        };
+        let original = to_matrix(&h, rows, cols);
 
         full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
         let converged = full_decomp_sym(&mut h, &mut r, c, c, c);
 
-        let kernel = NdArray {
-            dims: vec![rows, cols],
-            data: h.clone(),
-        };
-        let rotation = NdArray {
-            dims: vec![rows, cols],
-            data: r.clone(),
-        };
+        let kernel = to_matrix(&h, rows, cols);
+        let rotation = to_matrix(&r, rows, cols);
+        let identity = Matrix2D::identity(c);
 
-        let identity = generate_identity_vector(rows, cols);
-        let rrt = matrix_mult(&rotation, &rotation.transpose());
-        let rtr = matrix_mult(&rotation.transpose(), &rotation);
-        let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+        let rrt = rotation.dot(&rotation.transpose()).unwrap();
+        let rtr = rotation.transpose().dot(&rotation).unwrap();
+        let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
 
-        let ortho_ok =
-            approx_vector_eq(&rrt.data, &identity) && approx_vector_eq(&rtr.data, &identity);
-        let recon_ok = approx_vector_eq(&reconstruct.data, &original.data);
+        let ortho_ok = approx_vector_eq(&flat(&rrt), &flat(&identity))
+            && approx_vector_eq(&flat(&rtr), &flat(&identity));
+        let recon_ok = approx_vector_eq(&flat(&reconstruct), &flat(&original));
 
         (converged, ortho_ok && recon_ok)
     }
+
     #[rustfmt::skip]
     #[test]
     fn test_symmetric_reconstruct() {
@@ -428,45 +474,37 @@ mod test_hessenberg_reconstructions {
         assert!(convergence_failures < 10, "too many convergence failures: {convergence_failures}");
         assert!(reconstruction_failures < 10, "too many reconstruction failures: {reconstruction_failures}");
     }
+
     fn check_decomp_cpx_reconstruct() -> (bool, bool) {
-        // returns (converged, reconstruction_ok)
         let c = 6;
         let (rows, cols) = (c, c);
         let stride = c;
 
         let mut h = generate_random_vector(rows * cols);
         let mut r = generate_identity_vector(rows, cols);
-        let mut p = vec![0f32; cols];
-        let mut w = vec![0f32; rows];
+        let mut p = vec![0f64; cols];
+        let mut w = vec![0f64; rows];
 
-        let original = NdArray {
-            dims: vec![rows, cols],
-            data: h.clone(),
-        };
+        let original = to_matrix(&h, rows, cols);
 
         full_hessenberg(&mut h, &mut r, &mut p, &mut w, rows, cols, stride);
         let converged = full_decomp_cpx(&mut h, &mut r, &mut w, c, c, c);
 
-        let kernel = NdArray {
-            dims: vec![rows, cols],
-            data: h.clone(),
-        };
-        let rotation = NdArray {
-            dims: vec![rows, cols],
-            data: r.clone(),
-        };
+        let kernel = to_matrix(&h, rows, cols);
+        let rotation = to_matrix(&r, rows, cols);
+        let identity = Matrix2D::identity(c);
 
-        let identity = generate_identity_vector(rows, cols);
-        let rrt = matrix_mult(&rotation, &rotation.transpose());
-        let rtr = matrix_mult(&rotation.transpose(), &rotation);
-        let reconstruct = matrix_mult(&rotation.transpose(), &matrix_mult(&kernel, &rotation));
+        let rrt = rotation.dot(&rotation.transpose()).unwrap();
+        let rtr = rotation.transpose().dot(&rotation).unwrap();
+        let reconstruct = rotation.transpose().dot(&kernel).unwrap().dot(&rotation).unwrap();
 
-        let ortho_ok =
-            approx_vector_eq(&rrt.data, &identity) && approx_vector_eq(&rtr.data, &identity);
-        let recon_ok = approx_vector_eq(&reconstruct.data, &original.data);
+        let ortho_ok = approx_vector_eq(&flat(&rrt), &flat(&identity))
+            && approx_vector_eq(&flat(&rtr), &flat(&identity));
+        let recon_ok = approx_vector_eq(&flat(&reconstruct), &flat(&original));
 
         (converged, ortho_ok && recon_ok)
     }
+
     #[rustfmt::skip]
     #[test]
     fn test_complex_reconstruct() {
@@ -476,15 +514,11 @@ mod test_hessenberg_reconstructions {
 
         for _ in 0..trials {
             let (converged, reconstructed) = check_decomp_cpx_reconstruct();
-            if !converged {
-                convergence_failures += 1;
-            }
-            if !reconstructed {
-                reconstruction_failures += 1;
-            }
+            if !converged { convergence_failures += 1; }
+            if !reconstructed { reconstruction_failures += 1; }
         }
         println!("cpx: {convergence_failures} convergence failures, {reconstruction_failures} reconstruction failures / {trials}");
-        assert!( convergence_failures < 10, "too many convergence failures: {convergence_failures}");
-        assert!( reconstruction_failures < 10, "too many reconstruction failures: {reconstruction_failures}");
+        assert!(convergence_failures < 10, "too many convergence failures: {convergence_failures}");
+        assert!(reconstruction_failures < 10, "too many reconstruction failures: {reconstruction_failures}");
     }
 }

--- a/spindalis/src/reduction/matrix/mod.rs
+++ b/spindalis/src/reduction/matrix/mod.rs
@@ -1,2 +1,3 @@
+pub mod francis;
 pub mod hessenberg;
 pub use hessenberg::hessenberg_reduction;


### PR DESCRIPTION
Adds a Francis-iteration eigenvalue solver for symmetric and general
(complex-eigenvalue) matrices, plus a thin Matrix2D-facing wrapper.

- Symmetric case uses Givens rotations (single-shift); complex case uses
  Householder reflections. Kept as separate code paths rather than routing
  everything through the general case, since the symmetric case is known
  to have real eigenvalues going in, and single-shift Givens converges
  better there than the double-shift approach needed for the general case.
- All hot-path functions are inline; constants (max_iters, tolerance,
  absolute bound) are tuned empirically for f32 workloads — will need
  re-tuning if this gets ported to f64/arbitrary precision, which is why
  I left that out of scope for now.
- Uses an LQ-style decomposition rather than QR (transpose of the usual
  approach) — slightly cleaner indexing for how I built the rotation
  accumulation. I track the left rotation (R[k]...R[n]) rather than the
  right.
- Eigenvalue shifting primarily uses a double-shift, with a nudge-shift applied
  via a mod function to knock the reduction out of local-minima spins.
- Test tolerance is 1e-2 for reconstruction checks — looks loose, but
  it's the error after two matmuls (Q^T H Q reconstruction), so it's
  tighter than it looks at first glance. Ideally this becomes a function
  of matrix size rather than a fixed constant — noted as a follow-up.
- Convergence: symmetric and complex cases both hit 99.99%+ success at
  6x6 across 10k random trials (<10 failures / 10k for both). Getting
  meaningfully closer to 100% would need more shift strategies and
  nontrivial additional work — not attempting that here.
- Added rand/rand_distr as dev-dependencies to generate random test
  matrices (rather than a handful of fixed fixtures), so convergence
  isn't overfit to a particular shift pattern or matrix shape.

Still rough edges I'm aware of:
- Matrix2D doesn't expose a way to get a flat mutable buffer over its
  backing storage, only per-row slices / (row,col) indexing. My internals
  are flat-buffer, in-place, stride-based (inline Householder zeroing,
  implicit Givens rotations — these get very awkward without direct
  buffer access), so the interface layer currently copies in/out via
  from_flat/rows().flatten(). Works fine, just extra allocation at the
  boundary.
- "Complex" throughout refers to complex eigenvalues, not complex matrix
  entries — the matrices themselves are real-valued.